### PR TITLE
Simplify local development experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Page text goes here
 The directory for a page can include other files related to that topic, like images or [Graphviz](https://graphviz.org/) files for generating diagrams.
 
 ## Building and testing
-In order to see content as it will appear online, it must be built first. As a pre-requisite, this project requires [Node.js](https://nodejs.org/en/). Run the following shell commands to build and locally serve the website:
+In order to see content as it will appear online, you can run c20 in development mode. As a pre-requisite, this project requires [Node.js](https://nodejs.org/en/). Run the following shell commands to build and locally serve the website:
 
 ```sh
 # install dependencies
@@ -41,13 +41,16 @@ git submodule update --init
 npm ci
 
 # build content into `./dist`
-npm run build
-
-# serve the site on port 8080
-npm start
+npm run dev
 ```
 
 You should be able to visit http://localhost:8080/ in a browser and see the built website. Note that if you make changes to source content, it will need to be rebuilt with `npm run build` before you see changes in the browser.
+
+If a different port is desired, set the environment variable `C20_PORT`:
+
+```sh
+C20_PORT=9001 npm run dev
+```
 
 ## Releasing
 The website is currently hosted as a static site in [AWS S3](https://aws.amazon.com/s3/), fronted by a [CloudFront](https://aws.amazon.com/cloudfront/) CDN distribution. To deploy a new version, simply sync the `dist` directory to S3:

--- a/build-config.json
+++ b/build-config.json
@@ -1,0 +1,15 @@
+{
+  "paths": {
+    "dist": "./dist",
+    "distAssets": "./dist/assets/",
+    "srcPages": "./src/content/**/readme.md",
+    "srcResources": "./src/content/**/*.@(jpg|jpeg|png|gif)",
+    "srcDiagrams": "./src/content/**/*.@(dot|neato|fdp|sfdp|twopi|circo)",
+    "srcContentBase": "./src/content",
+    "srcAssetImages": "./src/@(assets)/**/*.@(jpg|jpeg|png|gif)",
+    "srcStyleEntry": "./src/assets/style.scss",
+    "srcStylesAny": "./src/assets/**/*.scss",
+    "vendorAssets": ["./node_modules/highlight.js/styles/atom-one-dark.css"],
+    "invaderTagDefsBase": "./lib/invader/src/tag/hek/definition/"
+  }
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,21 +9,8 @@ const buildContent = require("./src/content");
 const Viz = require('viz.js');
 const vizRenderOpts = require('viz.js/full.render.js');
 
+const {paths} = require("./build-config.json");
 const runServer = require("./server");
-
-const paths = {
-  dist: "./dist",
-  distAssets: "./dist/assets/",
-  srcPages: "./src/content/**/readme.md",
-  srcResources: "./src/content/**/*.@(jpg|jpeg|png|gif)",
-  srcDiagrams: "./src/content/**/*.@(dot|neato|fdp|sfdp|twopi|circo)",
-  srcContentBase: "./src/content",
-  srcAssetImages: "./src/@(assets)/**/*.@(jpg|jpeg|png|gif)",
-  srcStyleEntry: "./src/assets/style.scss",
-  srcStylesAny: "./src/assets/**/*.scss",
-  vendorAssets: ["./node_modules/highlight.js/styles/atom-one-dark.css"],
-  invaderTagDefsBase: "./lib/invader/src/tag/hek/definition/",
-};
 
 //the dist directory may contain outdated content, so start clean
 function clean() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,60 +1,104 @@
 const gulp = require("gulp");
+const del = require("del");
 const sass = require("sass");
 const fs = require("fs");
+const path = require("path");
 const rename = require("gulp-rename");
 const transform = require("gulp-transform");
 const buildContent = require("./src/content");
 const Viz = require('viz.js');
 const vizRenderOpts = require('viz.js/full.render.js');
 
+const runServer = require("./server");
+
+const paths = {
+  dist: "./dist",
+  distAssets: "./dist/assets/",
+  srcPages: "./src/content/**/readme.md",
+  srcResources: "./src/content/**/*.@(jpg|jpeg|png|gif)",
+  srcDiagrams: "./src/content/**/*.@(dot|neato|fdp|sfdp|twopi|circo)",
+  srcContentBase: "./src/content",
+  srcAssetImages: "./src/@(assets)/**/*.@(jpg|jpeg|png|gif)",
+  srcStyleEntry: "./src/assets/style.scss",
+  srcStylesAny: "./src/assets/**/*.scss",
+  vendorAssets: ["./node_modules/highlight.js/styles/atom-one-dark.css"],
+  invaderTagDefsBase: "./lib/invader/src/tag/hek/definition/",
+};
+
+//the dist directory may contain outdated content, so start clean
+function clean() {
+  return del(paths.dist);
+}
+
+//build the stylesheet from SASS
 function assetStyles() {
   return new Promise((resolve, reject) => {
-    sass.render({file: "./src/assets/style.scss"}, (err, res) => {
+    sass.render({file: paths.srcStyleEntry}, (err, res) => {
       if (err) {
         reject(err);
       } else {
-        fs.mkdirSync("./dist/assets/", {recursive: true});
-        fs.writeFileSync("./dist/assets/style.css", res.css, "utf8");
+        fs.mkdirSync(paths.distAssets, {recursive: true});
+        fs.writeFileSync(path.join(paths.distAssets, "style.css"), res.css, "utf8");
         resolve();
       }
     });
   });
 }
 
+//copies any static image assets over to the dist directory
 function assetImages() {
-  return gulp.src("./src/@(assets)/**/*.@(jpg|jpeg|png|gif)")
-    .pipe(gulp.dest("./dist"));
+  return gulp.src(paths.srcAssetImages)
+    .pipe(gulp.dest(paths.dist));
 }
 
+//any assets which come from our dependencies can be copied over too
 function vendorAssets() {
-  return gulp.src("./node_modules/highlight.js/styles/atom-one-dark.css")
-    .pipe(gulp.dest("./dist/assets/"));
+  return gulp.src(paths.vendorAssets)
+    .pipe(gulp.dest(paths.distAssets));
 }
 
-//https://graphviz.org/documentation/
+//build content graphviz diagrams into SVG (https://graphviz.org)
 function contentDiagrams() {
-  return gulp.src("./src/content/**/*.@(dot|neato|fdp|sfdp|twopi|circo)")
+  return gulp.src(paths.srcDiagrams)
     .pipe(transform("utf8", (mermaidSrc) => {
       const viz = new Viz(vizRenderOpts);
       return viz.renderString(mermaidSrc);
     }))
     .pipe(rename({extname: ".svg"}))
-    .pipe(gulp.dest("./dist"));
+    .pipe(gulp.dest(paths.dist));
 }
 
+//content file types which we wish to copy over to dist
 function contentResources() {
-  return gulp.src("./src/content/**/*.@(jpg|jpeg|png|gif)")
-    .pipe(gulp.dest("./dist"));
+  return gulp.src(paths.srcResources)
+    .pipe(gulp.dest(paths.dist));
 }
 
+//index and render all readme.md files to HTML
 async function contentPages() {
-  await buildContent("./src/content", "./dist", "./lib/invader/src/tag/hek/definition/");
+  await buildContent(paths.srcContentBase, paths.dist, paths.invaderTagDefsBase);
 }
 
+function watchSources() {
+  gulp.watch([paths.srcAssetImages], assetImages);
+  gulp.watch([paths.srcStylesAny], assetStyles);
+  gulp.watch([paths.srcPages], contentPages);
+  gulp.watch([paths.srcResources], contentResources);
+  gulp.watch([paths.srcDiagrams], contentDiagrams);
+  runServer();
+}
+
+//composite tasks
 const assets = gulp.parallel(assetImages, assetStyles, vendorAssets);
 const content = gulp.parallel(contentResources, contentPages, contentDiagrams);
+const buildAll = gulp.series(clean, gulp.parallel(assets, content));
+const dev = gulp.series(buildAll, watchSources);
 
+//tasks which can be invoked from CLI with `npx gulp <taskname>`
 module.exports = {
-  assets,
-  default: gulp.parallel(assets, content)
+  clean, //remove the dist directory
+  assets, //build just styles
+  content, //build just page content
+  dev, //local development mode
+  default: buildAll //typical build for publishing content
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,54 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@nodelib/fs.scandir": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.3",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.3",
+        "fastq": "^1.6.0"
+      }
+    },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
+    },
     "@types/expect": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/@types/expect/-/expect-1.20.4.tgz",
       "integrity": "sha512-Q5Vn3yjTDyCMV50TB6VRIbQNxSE4OmZR86VSbGaNpfUolm0iePBB4KdEEHmxoY5sT2+2DIvXW0rvMDP2nHZ4Mg==",
       "dev": true
+    },
+    "@types/glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "dev": true,
+      "requires": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
     },
     "@types/gulp-util": {
       "version": "3.0.34",
@@ -21,6 +64,12 @@
         "@types/vinyl": "*",
         "chalk": "^2.2.0"
       }
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
     },
     "@types/node": {
       "version": "13.11.0",
@@ -54,6 +103,16 @@
       "requires": {
         "mime-types": "~2.1.24",
         "negotiator": "0.6.2"
+      }
+    },
+    "aggregate-error": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
       }
     },
     "ansi-colors": {
@@ -241,6 +300,12 @@
           "dev": true
         }
       }
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -551,6 +616,12 @@
         }
       }
     },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true
+    },
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -832,6 +903,22 @@
         }
       }
     },
+    "del": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-5.1.0.tgz",
+      "integrity": "sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==",
+      "dev": true,
+      "requires": {
+        "globby": "^10.0.1",
+        "graceful-fs": "^4.2.2",
+        "is-glob": "^4.0.1",
+        "is-path-cwd": "^2.2.0",
+        "is-path-inside": "^3.0.1",
+        "p-map": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "slash": "^3.0.0"
+      }
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -847,6 +934,23 @@
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      },
+      "dependencies": {
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+          "dev": true
+        }
+      }
     },
     "duplexer2": {
       "version": "0.0.2",
@@ -1205,6 +1309,83 @@
         "color-support": "^1.1.3",
         "parse-node-version": "^1.0.0",
         "time-stamp": "^1.0.0"
+      }
+    },
+    "fast-glob": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz",
+      "integrity": "sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2",
+        "picomatch": "^2.2.1"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
+    "fastq": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.7.0.tgz",
+      "integrity": "sha512-YOadQRnHd5q6PogvAR/x62BGituF2ufiEA6s8aavQANw5YKHERI4AREboX6KotzP8oX2klxYF2wcV/7bn1clfQ==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
       }
     },
     "file-uri-to-path": {
@@ -2021,6 +2202,22 @@
         "which": "^1.2.14"
       }
     },
+    "globby": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
+      "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "^7.1.1",
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.0.3",
+        "glob": "^7.1.3",
+        "ignore": "^5.1.1",
+        "merge2": "^1.2.3",
+        "slash": "^3.0.0"
+      }
+    },
     "glogg": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
@@ -2288,6 +2485,18 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ignore": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+      "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2471,6 +2680,18 @@
           }
         }
       }
+    },
+    "is-path-cwd": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+      "dev": true
+    },
+    "is-path-inside": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
+      "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+      "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -2857,6 +3078,12 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
+    "merge2": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+      "dev": true
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -3170,6 +3397,15 @@
         "lcid": "^1.0.0"
       }
     },
+    "p-map": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "dev": true,
+      "requires": {
+        "aggregate-error": "^3.0.0"
+      }
+    },
     "parse-filepath": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
@@ -3270,6 +3506,12 @@
         "pify": "^2.0.0",
         "pinkie-promise": "^2.0.0"
       }
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
     },
     "pify": {
       "version": "2.3.0",
@@ -3535,6 +3777,27 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "dev": true
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -3649,6 +3912,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
     },
     "snapdragon": {
       "version": "0.8.2",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,13 @@
   "main": "gulpfile.js",
   "scripts": {
     "build": "gulp",
-    "start": "node server.js"
+    "dev": "gulp dev",
+    "start": "node -e 'require(\"./server.js\")()'"
   },
+  "files": [
+    "dist",
+    "server.js"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/csauve/c20.git"
@@ -23,6 +28,7 @@
   },
   "devDependencies": {
     "common-tags": "^1.8.0",
+    "del": "^5.1.0",
     "front-matter": "^3.1.0",
     "glob": "^7.1.6",
     "gulp": "^4.0.2",

--- a/server.js
+++ b/server.js
@@ -1,6 +1,10 @@
 const express = require("express");
 const serveStatic = require("serve-static");
 
-const app = express();
-app.use("/", serveStatic("./dist"));
-app.listen(8080);
+module.exports = function() {
+  const port = process.env.C20_PORT ? Number(process.env.C20_PORT) : 8080;
+  const app = express();
+  app.use("/", serveStatic("./dist"));
+  app.listen(port);
+  console.log(`Serving at http://localhost:${port}/`);
+};


### PR DESCRIPTION
The local development experience currently requires you to repeatedly rebuild `dist` after content changes. It also requires you to serve the `dist` directory in another tab. This PR implements automatic rebuilding when source files are modified. Only the build task necessary for the file type is run. Additionally, the local development server is started automatically.

Assuming dependencies are already installed, local development can now begin with just:

```sh
npm run dev
```

The user can navigate to http://localhost:8080 and see changes to source content reflected when refreshing.