### PR TITLE
Group tag dependencies into sections by inheritance level

### DIFF
--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -41,6 +41,9 @@ img {
 a {
   color: $fg-link;
   text-decoration: none;
+  &:hover {
+    text-decoration: underline;
+  }
 }
 
 a[href^="mailto:"]:after {
@@ -78,6 +81,10 @@ main {
 hr {
   border: none;
   border-bottom: 1px solid $border-color;
+}
+
+details summary {
+  cursor: pointer;
 }
 
 h1.page-title {

--- a/src/content.js
+++ b/src/content.js
@@ -53,6 +53,7 @@ async function getPageMetadata(contentDir) {
             ...attributes,
             _md: body,
             _dir,
+            _slug: _dir[_dir.length - 1],
             _dirUrl: "/" + _dir.join("/")
           });
         }
@@ -69,7 +70,7 @@ async function buildMetaIndex(contentDir, tagsDir) {
 
   const mdFooter = pages
     .filter(page => page._dir.length > 0)
-    .map(page => `[${page._dir[page._dir.length - 1]}]: ${page._dirUrl}`)
+    .map(page => `[${page._slug}]: ${page._dirUrl}`)
     .join("\n");
 
   return {pages, mdFooter, tags};

--- a/src/content/blam/map/readme.md
+++ b/src/content/blam/map/readme.md
@@ -2,7 +2,7 @@
 title: Map cache file
 ---
 
-A map, also known as a **cache file**, is a bundle of compiled [tags][] which can be loaded and used by [Halo][ce]. As the name _cache_ suggests, Halo loads these into memory at game startup so that the tags within can be quickly read and accessed without having to load them from disk. With the exception of **resource maps** and **ui.map**, each map represents a playable campaign or multiplayer level.
+A map, also known as a **cache file**, is a bundle of compiled [tags][] which can be loaded and used by [Halo][h1]. As the name _cache_ suggests, Halo loads these into memory at game startup so that the tags within can be quickly read and accessed without having to load them from disk. With the exception of **resource maps** and **ui.map**, each map represents a playable campaign or multiplayer level.
 
 Maps are found in Halo's `maps` directory. Maps in subdirectories are not loaded by the game. Mods like Chimera and HAC2 store downloaded maps in a separate location and force the game to load them regardless.
 

--- a/src/templates/default.js
+++ b/src/templates/default.js
@@ -2,5 +2,5 @@ const {html} = require("common-tags");
 const {wrapper, renderMarkdown} = require("./shared");
 
 module.exports = (page, metaIndex) => wrapper(page, metaIndex, html`
-  ${renderMarkdown(page._md, metaIndex.mdFooter)}
+  ${renderMarkdown(page._md, metaIndex)}
 `);

--- a/src/templates/home.js
+++ b/src/templates/home.js
@@ -2,6 +2,6 @@ const {html} = require("common-tags");
 const {wrapper, ul, pageAnchor, renderMarkdown} = require("./shared");
 
 module.exports = (page, metaIndex) => wrapper(page, metaIndex, html`
-  ${renderMarkdown(page._md, metaIndex.mdFooter)}
+  ${renderMarkdown(page._md, metaIndex)}
   ${ul(metaIndex.pages.map((page) => pageAnchor(page)))}
 `);

--- a/src/templates/shared.js
+++ b/src/templates/shared.js
@@ -53,7 +53,7 @@ const STUB_ALERT = alert({type: "danger", body: html`
   pull requests or issues in this wiki's <a href="${REPO}">source repo</a>.</p>
 `});
 
-const metabox = ({metaTitle, metaColour, img, imgCaption, mdSections, mdFooter, htmlSections}) => {
+const metabox = ({metaTitle, metaColour, img, imgCaption, mdSections, metaIndex, htmlSections}) => {
   return html`
     <aside class="metabox">
       <section class="header" style="background: ${metaColour || "none"}">
@@ -66,12 +66,12 @@ const metabox = ({metaTitle, metaColour, img, imgCaption, mdSections, mdFooter, 
       `}
       ${imgCaption && html`
         <section class="caption">
-          <p><em>${renderMarkdown(imgCaption, mdFooter)}</em></p>
+          <p><em>${renderMarkdown(imgCaption, metaIndex)}</em></p>
         </section>
       `}
       ${mdSections && mdSections.filter(it => it).map(mdSection => html`
         <section class="info">
-          ${renderMarkdown(mdSection, mdFooter)}
+          ${renderMarkdown(mdSection, metaIndex)}
         </section>
       `)}
       ${htmlSections && htmlSections.filter(it => it).map(htmlSection => html`
@@ -83,8 +83,8 @@ const metabox = ({metaTitle, metaColour, img, imgCaption, mdSections, mdFooter, 
   `;
 };
 
-const renderMarkdown = (md, mdFooter) => {
-  return mdRenderer.render(mdFooter ? (md + "\n\n" + mdFooter) : md);
+const renderMarkdown = (md, metaIndex) => {
+  return mdRenderer.render(metaIndex ? (md + "\n\n" + metaIndex.mdFooter) : md);
 };
 
 const wrapper = (page, metaIndex, body) => {

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -17,7 +17,7 @@ function expandStructs(parentedStruct, tags) {
   return results;
 }
 
-function getTagDependencies(tagStruct, tags, dbg) {
+function getTagDependencies(tagStruct, tags) {
   if (!tagStruct) {
     return [];
   }
@@ -62,7 +62,7 @@ module.exports = (page, metaIndex) => {
     console.warn(`Failed to find tag structure for ${page.title}`);
   }
 
-  const tagDependencies = getTagDependencies(tagStruct, metaIndex.tags, page.title == "scenery");
+  const tagDependencies = getTagDependencies(tagStruct, metaIndex.tags);
 
   const tagDependencySections = tagDependencies.map(depLevel => {
     let parentTagClass = null;

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -1,36 +1,53 @@
 const {html} = require("common-tags");
 const {wrapper, renderMarkdown, metabox, alert, anchor} = require("./shared");
 
-function expandStructs(struct, tags) {
-  const structs = struct.fields
+function expandStructs(parentedStruct, tags) {
+  const {struct, parentName} = parentedStruct;
+  const results = struct.fields
     .filter(field => field.type == "TagReflexive" &&
       field.struct != "PredictedResource"
     )
-    .map(field => tags[field.struct]);
+    .map(field => ({struct: tags[field.struct], parentName}));
   if (struct.inherits) {
-    structs.push(tags[struct.inherits]);
+    results.push({
+      struct: tags[struct.inherits],
+      parentName: struct.inherits
+    });
   }
-  return structs;
+  return results;
 }
 
 function getTagDependencies(tagStruct, tags, dbg) {
   if (!tagStruct) {
     return [];
   }
-  let deps = new Set();
-  let structStack = expandStructs(tagStruct, tags);
+
+  const resultsLevels = [];
+  let structStack = [{struct: tagStruct, parentName: null}];
+
   while (structStack.length > 0) {
-    const struct = structStack.pop();
+    const parentedStruct = structStack.pop();
+    const {struct, parentName} = parentedStruct;
     struct.fields
       .filter(field => field.type == "TagDependency")
       .flatMap(field => field.classes)
-      .forEach(tagClass => deps.add(tagClass));
+      .forEach(tagClass => {
+        const resultLevel = resultsLevels.find(level => level.parentName == parentName);
+        if (resultLevel) {
+          resultLevel.deps.add(tagClass);
+        } else {
+          resultsLevels.push({parentName, deps: new Set([tagClass])});
+        }
+      });
     structStack = [
       ...structStack,
-      ...expandStructs(struct, tags)
+      ...expandStructs(parentedStruct, tags)
     ];
   }
-  return [...deps].sort();
+  return resultsLevels.map(({parentName, deps}) => ({
+    parentName,
+    deps: [...deps].sort()
+  }));
 }
 
 module.exports = (page, metaIndex) => {
@@ -45,24 +62,40 @@ module.exports = (page, metaIndex) => {
     console.warn(`Failed to find tag structure for ${page.title}`);
   }
 
-  const tagDependencies = getTagDependencies(tagStruct, metaIndex.tags);
+  const tagDependencies = getTagDependencies(tagStruct, metaIndex.tags, page.title == "scenery");
 
-  const tagDependenciesHtml = tagDependencies.length > 0 ? html`
-    <p>Dependencies:</p>
-    <ul>
-      ${tagDependencies.map(tagClass => {
-        if (tagClass == "*") {
-          //sound, effect, damage effect, sound looping, model animations, actor variants, and objects
-          return html`<li>(any tags referenced by scripts)</li>`;
-        } else {
-          const tagPageUrl = `/blam/tags/${tagClass}`;
-          return html`<li>${anchor(tagPageUrl, tagClass)}</li>`;
-        }
-      })}
-    </ul>
-  ` : html`
-    <p>Dependencies: None</p>
-  `;
+  const tagDependencySections = tagDependencies.map(depLevel => {
+    let parentTagClass = null;
+    let parentPage = null;
+
+    if (depLevel.parentName) {
+      parentTagClass = depLevel.parentName.toLowerCase();
+      parentPage = metaIndex.pages.find(page => page._slug == parentTagClass);
+    }
+
+    return html`
+      <p>
+        <details${depLevel.parentName ? "" : " open"}>
+          <summary>${parentPage ? anchor(parentPage._dirUrl, parentTagClass) : "Direct"} references</summary>
+          <ul>
+            ${depLevel.deps.map(tagClass => {
+              if (tagClass == "*") {
+                //sound, effect, damage effect, sound looping, model animations, actor variants, and objects
+                return html`<li>(any tags referenced by scripts)</li>`;
+              } else {
+                const tagPage = metaIndex.pages.find(page => page._slug == tagClass);
+                if (tagPage) {
+                  return html`<li>${anchor(tagPage._dirUrl, tagClass)}</li>`;
+                }
+                console.warn(`Unable to find the tag page for tag class ${tagClass}`);
+                return html`<li>${tagClass}</li>`;
+              }
+            })}
+          </ul>
+        </details>
+      </p>
+    `;
+  });
 
   const invaderSrcReference = `https://github.com/Kavawuvi/invader/blob/master/src/tag/hek/definition/${tagClassSnake}.json`;
 
@@ -70,18 +103,18 @@ module.exports = (page, metaIndex) => {
     ...page,
     metaTitle: `\u{1F3F7} ${tagClassSnake} (tag)`,
     metaColour: "#530000",
-    mdFooter: metaIndex.mdFooter,
+    metaIndex,
     mdSections: [
       page.info
     ],
     htmlSections: [
-      tagDependenciesHtml
+      ...tagDependencySections
     ]
   };
 
   return wrapper(page, metaIndex, html`
     ${metabox(metaboxOpts)}
-    ${renderMarkdown(page._md, metaIndex.mdFooter)}
+    ${renderMarkdown(page._md, metaIndex)}
     <h1 id="tag-structure">
       Tag structure
       <a href="#tag-structure" class="header-anchor">#</a>

--- a/src/templates/tool.js
+++ b/src/templates/tool.js
@@ -6,7 +6,7 @@ module.exports = (page, metaIndex) => {
     ...page,
     metaTitle: `\u{1F527} ${page.title} (tool)`,
     metaColour: "navy",
-    mdFooter: metaIndex.mdFooter,
+    metaIndex,
     mdSections: [
       page.info
     ]
@@ -14,6 +14,6 @@ module.exports = (page, metaIndex) => {
 
   return wrapper(page, metaIndex, html`
     ${metabox(metaboxOpts)}
-    ${renderMarkdown(page._md, metaIndex.mdFooter)}
+    ${renderMarkdown(page._md, metaIndex)}
   `);
 };


### PR DESCRIPTION
The tag dependency list in the tag metabox was pretty long and unruly. Users will likely only need to visit more directly related tag pages. To keep all potential references accessible, but reduce information overload, I've implemented grouping of tag dependencies by inheritance level in `<detail>` elements, which can be expanded and collapsed. Direct dependencies begin expanded, and otherwise these sections are collapsed.

I've additionally renamed "dependency" to "reference" in the UI, which I think has less of the connotation of being mandatory.

This PR also fixes a few bugs:
* Direct dependencies are now properly detected
* No longer linking to tag pages which dont exist
* Fixed broken links to tags which extend an abstract tag

<img width="386" alt="deps" src="https://user-images.githubusercontent.com/1519264/79036629-0dc07080-7b7f-11ea-95f3-4b5d56598417.png">
