### PR TITLE
Fix the indentation level of main body content for preformatted content

### DIFF
--- a/src/templates/default.js
+++ b/src/templates/default.js
@@ -1,5 +1,4 @@
-const {html} = require("common-tags");
-const {wrapper, renderMarkdown} = require("./shared");
+const {wrapper, renderMarkdown, html} = require("./shared");
 
 module.exports = (page, metaIndex) => wrapper(page, metaIndex, html`
   ${renderMarkdown(page._md, metaIndex)}

--- a/src/templates/home.js
+++ b/src/templates/home.js
@@ -1,5 +1,4 @@
-const {html} = require("common-tags");
-const {wrapper, ul, pageAnchor, renderMarkdown} = require("./shared");
+const {wrapper, ul, pageAnchor, renderMarkdown, html} = require("./shared");
 
 module.exports = (page, metaIndex) => wrapper(page, metaIndex, html`
   ${renderMarkdown(page._md, metaIndex)}

--- a/src/templates/shared.js
+++ b/src/templates/shared.js
@@ -1,9 +1,11 @@
 const path = require("path");
-const {html} = require("common-tags");
+const commonTags = require("common-tags");
 const markdownIt = require("markdown-it");
 const markdownItAnchors = require("markdown-it-anchor");
 const markdownItToC = require("markdown-it-table-of-contents");
 const hljs = require("highlight.js");
+
+const html = commonTags.stripIndent(commonTags.html);
 
 const REPO = "https://github.com/Sigmmma/c20";
 
@@ -112,7 +114,7 @@ const wrapper = (page, metaIndex, body) => {
           </nav>
           <article class="content">
             <h1 class="page-title">${page.title}</h1>
-            ${body}
+    ${body}
             ${page.stub && html`
               <hr/>
               ${STUB_ALERT}
@@ -148,6 +150,7 @@ const ul = (items) => html`
 `;
 
 module.exports = {
+  html,
   wrapper,
   ul,
   pageAnchor,

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -1,5 +1,4 @@
-const {html} = require("common-tags");
-const {wrapper, renderMarkdown, metabox, alert, anchor} = require("./shared");
+const {html, wrapper, renderMarkdown, metabox, alert, anchor} = require("./shared");
 
 function expandStructs(parentedStruct, tags) {
   const {struct, parentName} = parentedStruct;

--- a/src/templates/tool.js
+++ b/src/templates/tool.js
@@ -1,5 +1,4 @@
-const {html} = require("common-tags");
-const {wrapper, renderMarkdown, metabox, alert} = require("./shared");
+const {wrapper, renderMarkdown, metabox, alert, html} = require("./shared");
 
 module.exports = (page, metaIndex) => {
   const metaboxOpts = {


### PR DESCRIPTION
This fix ensures the main body markdown content is rendered without indent so that `<pre>` tags (like code blocks) display properly without extra indentation:

![tmp-pr3](https://user-images.githubusercontent.com/1519264/79302112-39559a80-7ea0-11ea-9b07-47fd76a9837e.png)

_(previously, the first line would display properly but subsequent lines in the code block would be indented many spaces)_

The template function `html` from commontags is re-exported from `shared.js` with an additional `stripIndent` wrapper, and the body's interpolation spot in the page wrapper is indented at the same level as the opening `<html>` tag.