### PR TITLE
Headers overhaul

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1028,12 +1028,6 @@
         "once": "^1.4.0"
       }
     },
-    "entities": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
-      "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
-      "dev": true
-    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -2837,15 +2831,6 @@
         "resolve": "^1.1.7"
       }
     },
-    "linkify-it": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
-      "dev": true,
-      "requires": {
-        "uc.micro": "^1.0.1"
-      }
-    },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -3002,29 +2987,10 @@
         "object-visit": "^1.0.0"
       }
     },
-    "markdown-it": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
-      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
-      "dev": true,
-      "requires": {
-        "argparse": "^1.0.7",
-        "entities": "~2.0.0",
-        "linkify-it": "^2.0.0",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
-      }
-    },
-    "markdown-it-anchor": {
-      "version": "5.2.7",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.2.7.tgz",
-      "integrity": "sha512-REFmIaSS6szaD1bye80DMbp7ePwsPNvLTR5HunsUcZ0SG0rWJQ+Pz24R4UlTKtjKBPhxo0v0tOBDYjZQQknW8Q==",
-      "dev": true
-    },
-    "markdown-it-table-of-contents": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.4.4.tgz",
-      "integrity": "sha512-TAIHTHPwa9+ltKvKPWulm/beozQU41Ab+FIefRaQV1NRnpzwcV9QOe6wXQS5WLivm5Q/nlo0rl6laGkMDZE7Gw==",
+    "marked": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
+      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
       "dev": true
     },
     "matchdep": {
@@ -3061,12 +3027,6 @@
           }
         }
       }
-    },
-    "mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
-      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -4322,12 +4282,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
-    },
-    "uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
     },
     "unc-path-regex": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,7 @@
     "gulp-rename": "^2.0.0",
     "gulp-transform": "^3.0.5",
     "highlight.js": "^9.18.1",
-    "markdown-it": "^10.0.0",
-    "markdown-it-anchor": "^5.2.7",
-    "markdown-it-table-of-contents": "^0.4.4",
+    "marked": "^0.8.2",
     "sass": "^1.26.3",
     "viz.js": "^2.1.2"
   }

--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -22,7 +22,7 @@ $font-family-headers: "ConvectionRegular", "Helvetica", sans-serif;
 $font-family-code: "Fira Code", monospace;
 $font-size-code: 10pt;
 $width-content: 60em;
-$transition-time: 0.3s;
+$transition-time: 0.25s;
 
 @font-face {
   font-family: ConvectionRegular;
@@ -47,6 +47,10 @@ body {
 
 * {
   box-sizing: border-box;
+}
+
+ul, ol {
+  padding-left: 2em;
 }
 
 img {
@@ -115,7 +119,7 @@ details summary {
 }
 
 h1.page-title {
-  font-size: 2.5em;
+  font-size: 2em;
 }
 
 a.header-anchor {
@@ -123,6 +127,9 @@ a.header-anchor {
   opacity: 0;
   padding: 0 0.5em;
   transition: opacity $transition-time;
+  &:hover {
+    text-decoration: none;
+  }
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -240,8 +247,12 @@ table {
 
 .content-sidebar {
   grid-area: sidebar;
-  padding: $padding-containers;
+  padding: 0 $padding-containers;
   max-width: 20em;
+
+  & > ul, ol {
+    padding-left: 1em;
+  }
 }
 
 .content-main {
@@ -252,7 +263,7 @@ table {
 
 .breadcrumbs {
   padding: $padding-containers;
-  ul {
+  ol {
     list-style: none;
     display: block;
     margin: 0;
@@ -327,7 +338,7 @@ table {
 .content-layout {
   display: grid;
   grid-template-rows: max-content 1fr;
-  grid-template-columns: 10% 80%;
+  grid-template-columns: 20% 80%;
   grid-template-areas:
     "sidebar main"
     "sidebar footer";
@@ -335,6 +346,10 @@ table {
 
 //mobile view
 @media all and (max-width: 40em) {
+  .top-header {
+    padding: $padding-containers-small;
+  }
+
   .content-layout {
     grid-template-columns: 100%;
     grid-template-areas: "main" "sidebar" "footer";

--- a/src/content/blam/tags/bitmap/readme.md
+++ b/src/content/blam/tags/bitmap/readme.md
@@ -12,8 +12,6 @@ info: >
 
 Bitmaps are used for visuals that need textures or sprites like environments, objects, effects, menus, etc.
 
-[[toc]]
-
 # Basics
 To store textures and images in maps we use bitmap tags. Bitmap tags on their simplest are compiled from a `.tif` file in your data directory.
 
@@ -139,7 +137,7 @@ _NOTE: Having multiple cube maps in one bitmap does not randomize them._
 
 <img src="media/bitmap_sprites_source_vs_tag.png" width="600">
 
-The sprite type allows a bitmap to contain a non-power-of-two texture, with support for animations with multiple permutations (sequences). Sprites are typically used for particles.  
+The sprite type allows a bitmap to contain a non-power-of-two texture, with support for animations with multiple permutations (sequences). Sprites are typically used for particles.
 
 ## Color Plate
 
@@ -165,7 +163,7 @@ Any amount of padding may be used as long as the sprite is isolated by at least 
 
 Budget size determines how big each texture page is (and thus how many sprites will appear on each page). Budget count sets how many texture pages there will be. Both of these values should be set for sprites.
 
-When compiling a bitmap, tool will output how many pages were generated and the percentage of space filled by the sprites. Budget size and count should be tweaked to get this percentage as high as possible, as unused space is wasted memory.  
+When compiling a bitmap, tool will output how many pages were generated and the percentage of space filled by the sprites. Budget size and count should be tweaked to get this percentage as high as possible, as unused space is wasted memory.
 
 Budget sizes are limited to "square" dimensions like 256x256 and 512x512. Because of this, it is sometimes more memory efficient to split the sprites up across several pages. For example, putting a sprite sheet with seven 56x56 sprites on a single page would require a 512x512 budget size, because 512x512 is the smallest size that can fit all of the sprites. However, If that same sprite sheet was split up across two pages, each page would only need to be  256x256, cutting memory usage in half.
 

--- a/src/content/blam/tags/model_collision_geometry/readme.md
+++ b/src/content/blam/tags/model_collision_geometry/readme.md
@@ -13,7 +13,7 @@ Beyond having a collision mesh, these tags can also contain:
 * Damage ratios for each part of the object (e.g. weak points)
 * Shield and health values
 
-Collision geometry, rather than the [model][gbxmodel], is used to cast [scenery][] shadows in [lightmaps][scenario_structure_bsp].
+Collision geometry, rather than the [model][gbxmodel], is used to cast [scenery][] shadows in [lightmaps][scenario_structure_bsp#lightmaps].
 
 # Pathfinding spheres
 

--- a/src/content/blam/tags/scenario_structure_bsp/readme.md
+++ b/src/content/blam/tags/scenario_structure_bsp/readme.md
@@ -10,8 +10,6 @@ Commonly referred to as the **BSP**, this tag contains level geometry, weather d
 
 While a [scenario][] can reference multiple BSPs, Halo can only have a single BSP loaded at a time. Transitions between BSPs can be scripted (`switch_bsp`), e.g. using trigger volumes. Objects in unloaded BSPs are not simulated.
 
-[[toc]]
-
 # Binary space partitioning
 BSP stands for **[Binary Space Partitioning](bsp)**, a technique where space within a sealed static mesh is recursively subdivided by planes into [convex][] _leaf nodes_. The resulting **BSP tree** can be used to efficiently answer geometric queries, such as which surfaces should be collision-tested for physics objects.
 

--- a/src/content/games/h1/arguments/readme.md
+++ b/src/content/games/h1/arguments/readme.md
@@ -6,8 +6,6 @@ Halo accepts [command line/shortcut arguments][about-args] to customize how the 
 
 Many of these settings can be configured in-game, so it is not usually necessary to provide them as arguments.
 
-[[toc]]
-
 # How to add arguments to a shortcut (Windows)
 
 Windows users looking to avoid having to use the [command prompt][about-cmd] can create a shortcut to `halo.exe`, `haloce.exe`, or `haloceded.exe` and edit it's **target** to provide these arguments. Be sure to place them **after the EXE**, and **separate each argument with spaces**:

--- a/src/content/games/h1/readme.md
+++ b/src/content/games/h1/readme.md
@@ -15,8 +15,6 @@ Halo: Combat Evolved, also known as **Halo 1** (hereafter called Halo 1), is the
 
 Halo 1 uses Bungie's proprietary [Blam!][blam] engine, which also formed the basis of later games in the series. PC versions of the game support a variety of command line/shortcut [arguments][] to configure and toggle features.
 
-[[toc]]
-
 # Editions and versions
 
 <figure>

--- a/src/templates/shared/bits.js
+++ b/src/templates/shared/bits.js
@@ -1,19 +1,32 @@
 const commonTags = require("common-tags");
 
+const DISCORD_URL = "https://discord.reclaimers.net";
+const REPO_URL = "https://github.com/Sigmmma/c20";
+
+//converts a title into a URL- or ID-friendly slug
+const slugify = (title) => title
+  .toLowerCase()
+  .replace(/['-]/g, "")
+  .replace(/[^a-z0-9]/g, " ")
+  .split(" ")
+  .filter(part => part.length > 0)
+  .join("-");
+
+const escapeHtml = (s) => commonTags.safeHtml`${s}`;
 const html = commonTags.stripIndent(commonTags.html);
 
 const anchor = (href, body) => html`
   <a href="${href}">${body}</a>
 `;
 
-const pageAnchor = (page) => anchor(page._dirUrl, page.title);
+const pageAnchor = (page) => anchor(page._dirUrl, escapeHtml(page.title));
 
 const ol = (items) => html`
-  <ul>
+  <ol>
     ${items.map((item) => html`
       <li>${item}</li>
     `)}
-  <ul>
+  </ol>
 `;
 
 const ul = (items) => html`
@@ -21,7 +34,7 @@ const ul = (items) => html`
     ${items.map((item) => html`
       <li>${item}</li>
     `)}
-  <ul>
+  </ul>
 `;
 
 const alert = ({type, body}) => html`
@@ -32,9 +45,13 @@ const alert = ({type, body}) => html`
 
 module.exports = {
   html,
+  escapeHtml,
   anchor,
   pageAnchor,
   ul,
   ol,
-  alert
+  alert,
+  slugify,
+  REPO_URL,
+  DISCORD_URL
 };

--- a/src/templates/shared/breadcrumbs.js
+++ b/src/templates/shared/breadcrumbs.js
@@ -1,0 +1,18 @@
+const {ol, pageAnchor, escapeHtml} = require("./bits");
+
+const breadcrumbs = (page, metaIndex) => {
+  const breadcrumbs = [];
+  for (let i = 0; i <= page._dir.length; i++) {
+    const parentUrl = "/" + page._dir.slice(0, i).join("/");
+    const parent = metaIndex.pages.find(otherPage => otherPage._dirUrl == parentUrl);
+    if (parent) {
+      breadcrumbs.push(parent);
+    }
+  }
+
+  return ol(breadcrumbs.map((page, i) =>
+    (i < breadcrumbs.length - 1) ? pageAnchor(page) : escapeHtml(page.title)
+  ));
+};
+
+module.exports = breadcrumbs;

--- a/src/templates/shared/footer.js
+++ b/src/templates/shared/footer.js
@@ -1,0 +1,22 @@
+const {html, REPO_URL} = require("./bits");
+
+const LICENSE_URL = "https://creativecommons.org/licenses/by-sa/3.0/";
+
+const footer = (page) => {
+  const srcUrl = `${REPO_URL}/tree/master/src/content${page._dirUrl}`;
+  return html`
+    <footer class="content-footer">
+      <p>
+        <small>
+          This text is available under the <a href="${LICENSE_URL}">CC BY-SA 3.0 license</a>
+          •
+          <a href="${srcUrl}">Source</a>
+          •
+          <a href="#">Go to top</a>
+        </small>
+      </p>
+    </footer>
+  `;
+};
+
+module.exports = footer;

--- a/src/templates/shared/header.js
+++ b/src/templates/shared/header.js
@@ -1,0 +1,17 @@
+const {html, DISCORD_URL, REPO_URL} = require("./bits");
+
+const header = () => html`
+  <header class="top-header">
+    <a class="c20-logo" href="/">
+      <span class="c20-name-short">c20</span>
+      <span class="c20-name-long">The Reclaimers Library</span>
+    </a>
+    <nav class="c20-top-nav">
+      <input type="text" class="search" disabled placeholder="Search not implemented"></input>
+      <a href="${DISCORD_URL}">Discord</a>
+      <a href="${REPO_URL}">Contribute</a>
+    </nav>
+  </header>
+`;
+
+module.exports = header;

--- a/src/templates/shared/index.js
+++ b/src/templates/shared/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   wrapper: require("./wrapper"),
-  renderMarkdown: require("./markdown"),
   metabox: require("./metabox"),
+  ...require("./markdown"),
   ...require("./bits")
 };

--- a/src/templates/shared/markdown.js
+++ b/src/templates/shared/markdown.js
@@ -1,43 +1,64 @@
-const markdownIt = require("markdown-it");
-const markdownItAnchors = require("markdown-it-anchor");
-const markdownItToC = require("markdown-it-table-of-contents");
+const marked = require("marked");
 const hljs = require("highlight.js");
+const {slugify} = require("./bits");
 
-const mdRenderer = markdownIt({
-  html: true,
-  linkify: true,
-  typographer: false,
-  breaks: false,
-  highlight: (code, lang) => {
-    if (lang && hljs.getLanguage(lang)) {
-      try {
-        return hljs.highlight(lang, code).value;
-      } catch (err) {
-        console.warn(`Failed to highlight code with language ${lang}`);
-      }
-    }
-    return code;
-  }
-});
+//https://marked.js.org/#/USING_PRO.md#renderer
+const renderer = new marked.Renderer();
 
-//prevents protocol-less links from being turned into <a>
-mdRenderer.linkify.set({
-  fuzzyLink: false
-});
-
-//anchor options here: https://www.npmjs.com/package/markdown-it-anchor
-mdRenderer.use(markdownItAnchors, {
-  permalink: true,
-  permalinkSymbol: "#"
-});
-
-mdRenderer.use(markdownItToC, {
-  includeLevel: [1, 2],
-  containerHeaderHtml: "<h2 id=\"table-of-contents\">Table of contents</h2>"
-});
-
-const renderMarkdown = (md, metaIndex) => {
-  return mdRenderer.render(metaIndex ? (md + "\n\n" + metaIndex.mdFooter) : md);
+renderer.heading = function(text, level) {
+  const hN = "h" + level;
+  const slug = slugify(text);
+  const anchorLink = `<a class="header-anchor" href="#${slug}">#</a>`;
+  return `<${hN} id="${slug}">${text}${anchorLink}</${hN}>`;
 };
 
-module.exports = renderMarkdown;
+marked.setOptions({
+  renderer,
+  highlight: function(code, language) {
+    const validLanguage = hljs.getLanguage(language) ? language : "plaintext";
+    return hljs.highlight(validLanguage, code).value;
+  },
+  pedantic: false,
+  headerIds: false, //we'll do it ourselves via custom render
+  gfm: true,
+  breaks: false,
+  sanitize: false,
+  smartLists: true,
+});
+
+const walk = (tokens, type, cb) => {
+  if (tokens) {
+    tokens.forEach((token) => {
+      if (!type || token.type == type) {
+        cb(token);
+      }
+      walk(token.tokens);
+    });
+  }
+};
+
+const findHeaders = (mdSrc) => {
+  const tokens = marked.lexer(mdSrc);
+  const headers = [];
+
+  walk(tokens, "heading", (headingToken) => {
+    let title = headingToken.text;
+    headers.push({
+      title,
+      id: slugify(title),
+      level: headingToken.depth
+    });
+  });
+
+  return headers;
+};
+
+const renderMarkdown = (md, metaIndex) => {
+  const mdSrc = metaIndex ? (md + "\n\n" + metaIndex.mdFooter) : md;
+  return marked(mdSrc);
+};
+
+module.exports = {
+  findHeaders,
+  renderMarkdown
+};

--- a/src/templates/shared/metabox.js
+++ b/src/templates/shared/metabox.js
@@ -1,5 +1,5 @@
 const {html} = require("./bits");
-const renderMarkdown = require("./markdown");
+const {renderMarkdown} = require("./markdown");
 
 const metabox = ({metaTitle, metaColour, img, imgCaption, mdSections, metaIndex, htmlSections}) => {
   return html`

--- a/src/templates/shared/toc.js
+++ b/src/templates/shared/toc.js
@@ -1,0 +1,33 @@
+const {escapeHtml, html} = require("./bits");
+
+const TOC_LEVELS = 2;
+
+const toc = (page) => {
+  //convert headers to a tree structure
+  let listHtml = "";
+  let currentLevel = 0;
+  for (let header of page._headers.filter(it => it.level <= TOC_LEVELS)) {
+    if (header.level > currentLevel) {
+      listHtml += `\n${"  ".repeat(currentLevel)}<ul>`;
+      currentLevel = header.level;
+    } else if (header.level < currentLevel) {
+      currentLevel = header.level;
+      listHtml += `</li>\n${"  ".repeat(currentLevel)}</ul>`;
+      listHtml += `\n${"  ".repeat(currentLevel)}</li>`;
+    } else {
+      listHtml += "</li>";
+    }
+    listHtml += `\n${"  ".repeat(currentLevel)}<li><a href="#${header.id}">${escapeHtml(header.title)}</a>`;
+  }
+  while (currentLevel > 0) {
+    currentLevel--;
+    listHtml += `</li>\n${"  ".repeat(currentLevel)}</ul>`;
+  }
+
+  return html`
+    <h2 id="table-of-contents">On this page</h2>
+    ${listHtml}
+  `;
+};
+
+module.exports = toc;

--- a/src/templates/shared/wrapper.js
+++ b/src/templates/shared/wrapper.js
@@ -1,7 +1,15 @@
-const {html, alert, ol, pageAnchor} = require("./bits");
+const {html, alert, escapeHtml, REPO_URL, DISCORD_URL, ul, anchor} = require("./bits");
+const footer = require("./footer");
+const header = require("./header");
+const breadcrumbs = require("./breadcrumbs");
+const toc = require("./toc");
 
-const DISCORD_URL = "https://discord.reclaimers.net";
-const REPO_URL = "https://github.com/Sigmmma/c20";
+const TOC_MIN_HEADERS = 2;
+
+const topLevelTopics = [
+  ["/blam/tags", "Tags"],
+  ["/games/h1", "Halo"]
+];
 
 const STUB_ALERT = alert({type: "danger", body: html`
   <p>🚧 This article is a stub. You can help expand it by submitting content in
@@ -9,19 +17,12 @@ const STUB_ALERT = alert({type: "danger", body: html`
 `});
 
 const wrapper = (page, metaIndex, body) => {
-  const srcUrl = `${REPO_URL}/tree/master/src/content${page._dirUrl}`;
   const imgAbsoluteUrl = page.img ?
     `${metaIndex.baseUrl}${page._dirUrl}/${page.img}` :
     `${metaIndex.baseUrl}/assets/librarian.png`;
 
-  const breadcrumbs = [];
-  for (let i = 0; i <= page._dir.length; i++) {
-    const parentUrl = "/" + page._dir.slice(0, i).join("/");
-    const parent = metaIndex.pages.find(otherPage => otherPage._dirUrl == parentUrl);
-    if (parent) {
-      breadcrumbs.push(parent);
-    }
-  }
+  const showToc = page.toc !== undefined ? page.toc : page._headers.length > TOC_MIN_HEADERS;
+
   return html`
     <!DOCTYPE html>
     <html lang="en">
@@ -41,28 +42,19 @@ const wrapper = (page, metaIndex, body) => {
         <link rel="stylesheet" href="/assets/atom-one-dark.css"/>
       </head>
       <body>
-        <header class="top-header">
-          <a class="c20-logo" href="/">
-            <span class="c20-name-short">c20</span>
-            <span class="c20-name-long">The Reclaimers Library</span>
-          </a>
-          <nav class="c20-top-nav">
-            <input type="text" class="search" disabled placeholder="Search not implemented"></input>
-            <a href="${DISCORD_URL}">Discord</a>
-            <a href="${REPO_URL}">Contribute</a>
-          </nav>
-        </header>
+        ${header()}
         <div class="content-layout">
           <aside class="content-sidebar">
+            ${showToc && toc(page)}
+            <h2>Main topics</h2>
+            ${ul(topLevelTopics.map(topic => anchor(...topic)))}
           </aside>
           <main role="main" class="content-main">
             <nav class="breadcrumbs">
-              ${ol(breadcrumbs.map((page, i) =>
-                (i < breadcrumbs.length - 1) ? pageAnchor(page) : page.title
-              ))}
+              ${breadcrumbs(page, metaIndex)}
             </nav>
             <article class="content-article">
-              <h1 class="page-title">${page.title}</h1>
+              <h1 class="page-title">${escapeHtml(page.title)}</h1>
     ${body}
               ${page.stub && html`
                 <hr/>
@@ -70,17 +62,7 @@ const wrapper = (page, metaIndex, body) => {
               `}
             </article>
           </main>
-          <footer class="content-footer">
-            <p>
-              <small>
-                This text is available under the <a href="https://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0 license</a>
-                •
-                <a href="${srcUrl}">Source</a>
-                •
-                <a href="#">Go to top</a>
-              </small>
-            </p>
-          </footer>
+          ${footer(page)}
         </div>
       </body>
     </html>

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -111,7 +111,16 @@ module.exports = (page, metaIndex) => {
     ]
   };
 
-  return wrapper(page, metaIndex, html`
+  //because we're adding headers to the page, should update the headers list for ToC
+  const pageMetaForWrapper = {
+    ...page,
+    _headers: [
+      ...page._headers,
+      {title: "Tag structure", id: "tag-structure", level: 1}
+    ]
+  };
+
+  return wrapper(pageMetaForWrapper, metaIndex, html`
     ${metabox(metaboxOpts)}
     ${renderMarkdown(page._md, metaIndex)}
     <h1 id="tag-structure">


### PR DESCRIPTION
This PR accomplishes 3 goals related to headers:

* We are now able to link across pages using header anchors like `[Link][other-page#header]`
* The sidebar shows page headers in a Table of Contents. This is done automatically for any page with a sufficient number of headers, removing the need for manual `[[toc]]` placement
* The ToC is now generated outside the markdown rendering context, meaning we can insert additional headers from our page templates (e.g. "Tag Structure" is now present)

To make these changes, I needed to switch markdown rendering libraries from `commonmark-it` to `marked`, which offers easier extensibility for tasks like finding headers from the syntax tree and customizing how tokens are rendered.

I've also organized the shared templates a bit differently based on feedback from the previous PR, with components of `wrapper.js` now being split out into different files.

<img width="1436" alt="layout" src="https://user-images.githubusercontent.com/1519264/79705110-59eb6f00-8269-11ea-815a-81d78053429c.png">
