### PR TITLE
Show child pages in the sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /dist
 node_modules
 /src/content/todo
+report.*.json

--- a/src/content.js
+++ b/src/content.js
@@ -37,27 +37,37 @@ async function getTagMetadata(tagsDir) {
   return defsByName;
 }
 
+function getPagePathParts(contentDir, readmeFilePath) {
+  const {dir} = path.parse(readmeFilePath);
+  const contentDirDepth = path.normalize(contentDir).split(path.sep).length;
+  return path.normalize(dir).split(path.sep).slice(contentDirDepth);
+}
+
+//return an array of the metadata objects representing each content page
 async function getPageMetadata(contentDir) {
-  const filePaths = await findPaths(path.join(contentDir, "**/readme.md"));
-  return await Promise.all(filePaths.map(async (filePath) => {
+  //find all readme files under the content root -- each will become a page
+  const readmeFilePaths = await findPaths(path.join(contentDir, "**/readme.md"));
+
+  //build the array of per-page metadata
+  const pages = await Promise.all(readmeFilePaths.map(async (readmeFilePath) => {
     return new Promise(async (resolve, reject) => {
       try {
-        const fileContents = await fs.readFile(filePath, "utf8");
-        const {dir} = path.parse(filePath);
+        const fileContents = await fs.readFile(readmeFilePath, "utf8");
         const {attributes, body} = fm(fileContents);
         if (!attributes || !attributes.title) {
-          reject(new Error(`File ${filePath} does not define a title`));
+          reject(new Error(`File ${readmeFilePath} does not define a title`));
         } else {
-          const contentDirDepth = path.normalize(contentDir).split(path.sep).length;
-          const _dir = path.normalize(dir).split(path.sep).slice(contentDirDepth);
+          const _pathParts = getPagePathParts(contentDir, readmeFilePath);
           const _headers = findHeaders(body);
           resolve({
+            //include any YAML metadata provided by page authors
             ...attributes,
+            //add calulated or parsed metadata
             _md: body,
             _headers,
-            _dir,
-            _slug: _dir[_dir.length - 1],
-            _dirUrl: "/" + _dir.join("/"),
+            _pathParts,
+            _slug: _pathParts[_pathParts.length - 1],
+            _path: "/" + _pathParts.join("/"),
           });
         }
       } catch (err) {
@@ -65,6 +75,32 @@ async function getPageMetadata(contentDir) {
       }
     });
   }));
+
+  //in a second pass, add inter-page relationships like parents and children
+  for (let page of pages) {
+    //find the parent of this page
+    for (let i = page._pathParts.length - 1; i >= 0; i--) {
+      const parentPath = "/" + page._pathParts.slice(0, i).join("/");
+      page._parent = pages.find(otherPage => otherPage._path == parentPath);
+      if (page._parent) {
+        break;
+      }
+    }
+
+    page._childPages = [];
+    const candidateChildPages = pages.filter(otherPage =>
+      otherPage._path != page._path && otherPage._path.startsWith(page._path)
+    );
+    candidateChildPages.sort((a, b) => a._pathParts.length - b._pathParts.length);
+    for (let childPage of candidateChildPages) {
+      if (!page._childPages.find(otherChild => childPage._path.startsWith(otherChild._path))) {
+        page._childPages.push(childPage);
+      }
+    }
+    page._childPages.sort((a, b) => a.title.localeCompare(b.title));
+  }
+
+  return pages;
 }
 
 async function buildMetaIndex(contentDir, tagsDir, baseUrl) {
@@ -72,10 +108,10 @@ async function buildMetaIndex(contentDir, tagsDir, baseUrl) {
   const tags = await getTagMetadata(tagsDir);
 
   const mdFooter = pages
-    .filter(page => page._dir.length > 0)
+    .filter(page => page._pathParts.length > 0)
     .flatMap(page => [
-      `[${page._slug}]: ${page._dirUrl}`,
-      ...page._headers.map(header => `[${page._slug}#${header.id}]: ${page._dirUrl}#${header.id}`)
+      `[${page._slug}]: ${page._path}`,
+      ...page._headers.map(header => `[${page._slug}#${header.id}]: ${page._path}#${header.id}`)
     ])
     .join("\n");
 
@@ -90,8 +126,8 @@ async function renderContent(metaIndex, outputDir) {
       throw new Error(`The template '${templateName}' does not exist`);
     }
     const result = renderTemplate(page, metaIndex);
-    await fs.mkdir(path.join(outputDir, ...page._dir), {recursive: true});
-    await fs.writeFile(path.join(outputDir, ...page._dir, "index.html"), result, "utf8");
+    await fs.mkdir(path.join(outputDir, ...page._pathParts), {recursive: true});
+    await fs.writeFile(path.join(outputDir, ...page._pathParts, "index.html"), result, "utf8");
   }));
 }
 

--- a/src/templates/shared/bits.js
+++ b/src/templates/shared/bits.js
@@ -19,7 +19,7 @@ const anchor = (href, body) => html`
   <a href="${href}">${body}</a>
 `;
 
-const pageAnchor = (page) => anchor(page._dirUrl, escapeHtml(page.title));
+const pageAnchor = (page) => anchor(page._path, escapeHtml(page.title));
 
 const ol = (items) => html`
   <ol>

--- a/src/templates/shared/breadcrumbs.js
+++ b/src/templates/shared/breadcrumbs.js
@@ -1,17 +1,16 @@
 const {ol, pageAnchor, escapeHtml} = require("./bits");
 
 const breadcrumbs = (page, metaIndex) => {
-  const breadcrumbs = [];
-  for (let i = 0; i <= page._dir.length; i++) {
-    const parentUrl = "/" + page._dir.slice(0, i).join("/");
-    const parent = metaIndex.pages.find(otherPage => otherPage._dirUrl == parentUrl);
-    if (parent) {
-      breadcrumbs.push(parent);
-    }
+  const breadcrumbs = [page];
+  let currPage = page;
+
+  while (currPage._parent) {
+    breadcrumbs.push(currPage._parent);
+    currPage = currPage._parent;
   }
 
-  return ol(breadcrumbs.map((page, i) =>
-    (i < breadcrumbs.length - 1) ? pageAnchor(page) : escapeHtml(page.title)
+  return ol(breadcrumbs.reverse().map((crumbPage, i) =>
+    (i < breadcrumbs.length - 1) ? pageAnchor(crumbPage) : escapeHtml(crumbPage.title)
   ));
 };
 

--- a/src/templates/shared/footer.js
+++ b/src/templates/shared/footer.js
@@ -3,7 +3,7 @@ const {html, REPO_URL} = require("./bits");
 const LICENSE_URL = "https://creativecommons.org/licenses/by-sa/3.0/";
 
 const footer = (page) => {
-  const srcUrl = `${REPO_URL}/tree/master/src/content${page._dirUrl}`;
+  const srcUrl = `${REPO_URL}/tree/master/src/content${page._path}`;
   return html`
     <footer class="content-footer">
       <p>

--- a/src/templates/shared/markdown.js
+++ b/src/templates/shared/markdown.js
@@ -15,6 +15,10 @@ renderer.heading = function(text, level) {
 marked.setOptions({
   renderer,
   highlight: function(code, language) {
+    //clojure provides good highlighting for haloscript
+    if (language == "hsc") {
+      language = "clojure";
+    }
     const validLanguage = hljs.getLanguage(language) ? language : "plaintext";
     return hljs.highlight(validLanguage, code).value;
   },

--- a/src/templates/shared/wrapper.js
+++ b/src/templates/shared/wrapper.js
@@ -1,4 +1,4 @@
-const {html, alert, escapeHtml, REPO_URL, DISCORD_URL, ul, anchor} = require("./bits");
+const {html, alert, escapeHtml, REPO_URL, DISCORD_URL, ul, anchor, pageAnchor} = require("./bits");
 const footer = require("./footer");
 const header = require("./header");
 const breadcrumbs = require("./breadcrumbs");
@@ -18,7 +18,7 @@ const STUB_ALERT = alert({type: "danger", body: html`
 
 const wrapper = (page, metaIndex, body) => {
   const imgAbsoluteUrl = page.img ?
-    `${metaIndex.baseUrl}${page._dirUrl}/${page.img}` :
+    `${metaIndex.baseUrl}${page._path}/${page.img}` :
     `${metaIndex.baseUrl}/assets/librarian.png`;
 
   const showToc = page.toc !== undefined ? page.toc : page._headers.length > TOC_MIN_HEADERS;
@@ -34,7 +34,7 @@ const wrapper = (page, metaIndex, body) => {
         <meta property="og:site_name" content="The Reclaimers Library"/>
         <meta property="og:type" content="website"/>
         <meta property="og:locale" content="en_US"/>
-        <meta property="og:url" content="${metaIndex.baseUrl}${page._dirUrl}"/>
+        <meta property="og:url" content="${metaIndex.baseUrl}${page._path}"/>
         <meta property="og:image" content="${imgAbsoluteUrl}"/>
         <title>${page.title} - c20</title>
         <link rel="icon" type="image/png" href="/assets/librarian.png">
@@ -46,6 +46,10 @@ const wrapper = (page, metaIndex, body) => {
         <div class="content-layout">
           <aside class="content-sidebar">
             ${showToc && toc(page)}
+            ${page._childPages.length > 0 && html`
+              <h2>Child pages</h2>
+              ${ul(page._childPages.map(pageAnchor))}
+            `}
             <h2>Main topics</h2>
             ${ul(topLevelTopics.map(topic => anchor(...topic)))}
           </aside>

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -50,7 +50,7 @@ function getTagDependencies(tagStruct, tags) {
 }
 
 module.exports = (page, metaIndex) => {
-  const tagClassSnake = page._dir[page._dir.length - 1];
+  const tagClassSnake = page._pathParts[page._pathParts.length - 1];
   const tagClassPascal = page.tagClass || tagClassSnake
     .split("_")
     .map(part => `${part[0].toUpperCase()}${part.substring(1)}`)
@@ -75,7 +75,7 @@ module.exports = (page, metaIndex) => {
     return html`
       <p>
         <details${depLevel.parentName ? "" : " open"}>
-          <summary>${parentPage ? anchor(parentPage._dirUrl, parentTagClass) : "Direct"} references</summary>
+          <summary>${parentPage ? anchor(parentPage._path, parentTagClass) : "Direct"} references</summary>
           <ul>
             ${depLevel.deps.map(tagClass => {
               if (tagClass == "*") {
@@ -84,7 +84,7 @@ module.exports = (page, metaIndex) => {
               } else {
                 const tagPage = metaIndex.pages.find(page => page._slug == tagClass);
                 if (tagPage) {
-                  return html`<li>${anchor(tagPage._dirUrl, tagClass)}</li>`;
+                  return html`<li>${anchor(tagPage._path, tagClass)}</li>`;
                 }
                 console.warn(`Unable to find the tag page for tag class ${tagClass}`);
                 return html`<li>${tagClass}</li>`;


### PR DESCRIPTION
Adds a list of **direct child** pages to the sidebar when applicable:

<img width="1427" alt="child pages" src="https://user-images.githubusercontent.com/1519264/80189131-0c536700-85c7-11ea-86c0-d0178f3fabb4.png">
