### PR TITLE
Add child tags list to metabox

### DIFF
--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -47,7 +47,11 @@ function getTagDependencies(tagStruct, tags) {
 
 function getChildTags(tagStruct, tags) {
   return Object.values(tags).filter(otherTagStruct =>
-    otherTagStruct.inherits == tagStruct.name
+    //Invader's BasicObject is the only inherited struct which is not a traditional tag type
+    otherTagStruct.name != "BasicObject" && (
+      otherTagStruct.inherits == tagStruct.name ||
+      tagStruct.name == "Object" && otherTagStruct.inherits == "BasicObject"
+    )
   );
 }
 


### PR DESCRIPTION
Adds a list of inheriting child tags to the metabox for applicable abstract tags (e.g. unit, item, object). The list appears in the metabox, but is collapsed by default since the same list will also appear in the sidebar's child pages list. I don't consider this to be redundant information because this is about data structure relationships rather than page relationships, and in the future we may have pages adjacent to tags which do not represent tags themselves.

When we don't have a tag page for one of Invader's structs (e.g. Garbage), the struct name is shown instead of a link to a wiki page. These will clear out as we add stubs for all tags.

<img width="352" alt="childtags" src="https://user-images.githubusercontent.com/1519264/80272703-ab886500-8680-11ea-933b-64f14135c6f5.png">
