### PR TITLE
Add opengraph descriptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2459,6 +2459,12 @@
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
     },
+    "html-entities": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.1.tgz",
+      "integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA==",
+      "dev": true
+    },
     "http-errors": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "gulp-rename": "^2.0.0",
     "gulp-transform": "^3.0.5",
     "highlight.js": "^9.18.1",
+    "html-entities": "^1.3.1",
     "marked": "^0.8.2",
     "sass": "^1.26.3",
     "viz.js": "^2.1.2"

--- a/src/templates/shared/markdown.js
+++ b/src/templates/shared/markdown.js
@@ -1,17 +1,20 @@
 const marked = require("marked");
 const hljs = require("highlight.js");
+const Entities = require('html-entities').AllHtmlEntities;
 const {slugify, heading} = require("./bits");
 
-//https://marked.js.org/#/USING_PRO.md#renderer
-const renderer = new marked.Renderer();
+const entities = new Entities();
 
-renderer.heading = function(text, level) {
+//https://marked.js.org/#/USING_PRO.md#renderer
+const htmlRenderer = new marked.Renderer();
+
+htmlRenderer.heading = function(text, level) {
   const hN = "h" + level;
   return heading(hN, text);
 };
 
-marked.setOptions({
-  renderer,
+const htmlRenderOptions = {
+  renderer: htmlRenderer,
   highlight: function(code, language) {
     //clojure provides good highlighting for haloscript
     if (language == "hsc") {
@@ -26,7 +29,41 @@ marked.setOptions({
   breaks: false,
   sanitize: false,
   smartLists: true,
-});
+};
+
+const plaintextRenderer = new marked.Renderer();
+//inline:
+plaintextRenderer.strong = (text) => text;
+plaintextRenderer.em = (text) => text;
+plaintextRenderer.codespan = (code) => code;
+plaintextRenderer.br = () => "\n";
+plaintextRenderer.del = (text) => text;
+plaintextRenderer.link = (href, title, text) => text;
+plaintextRenderer.image = (href, title, text) => `(${title})`;
+plaintextRenderer.text = (text) => text;
+//blocks:
+plaintextRenderer.code = (code, infostring, escaped) => `\n${code}\n`;
+plaintextRenderer.blockquote = (quote) => `\n${quote}\n`;
+plaintextRenderer.html = (html) => "";
+plaintextRenderer.heading = (text, level, raw, slugger) => `\n${text.toUpperCase()}\n\n`;
+plaintextRenderer.hr = () => "---\n";
+plaintextRenderer.list = (body, ordered, start) => `\n${body}\n`;
+plaintextRenderer.listitem = (text, task, checked) => `- ${text}\n`;
+plaintextRenderer.checkbox = (checked) => `[${checked ? "X" : " "}]\n`;
+plaintextRenderer.paragraph = (text) => `${text}\n`;
+plaintextRenderer.table = (header, body) => `${header}\n${body}\n`;
+plaintextRenderer.tablerow = (content) => `${content}|\n`;
+plaintextRenderer.tablecell = (content, flags) => `|${content}`;
+
+const plaintextRenderOptions = {
+  renderer: plaintextRenderer,
+  pedantic: false,
+  headerIds: false,
+  gfm: true,
+  breaks: false,
+  sanitize: false,
+  smartLists: true,
+};
 
 const walk = (tokens, type, cb) => {
   if (tokens) {
@@ -55,9 +92,11 @@ const findHeaders = (mdSrc) => {
   return headers;
 };
 
-const renderMarkdown = (md, metaIndex) => {
+const renderMarkdown = (md, metaIndex, plaintext) => {
   const mdSrc = metaIndex ? (md + "\n\n" + metaIndex.mdFooter) : md;
-  return marked(mdSrc);
+  return plaintext ?
+    entities.decode(marked(mdSrc, plaintextRenderOptions)) :
+    marked(mdSrc, htmlRenderOptions);
 };
 
 module.exports = {

--- a/src/templates/shared/wrapper.js
+++ b/src/templates/shared/wrapper.js
@@ -1,4 +1,5 @@
 const {html, alert, escapeHtml, REPO_URL, DISCORD_URL, ul, anchor, pageAnchor} = require("./bits");
+const {renderMarkdown} = require("./markdown");
 const footer = require("./footer");
 const header = require("./header");
 const breadcrumbs = require("./breadcrumbs");
@@ -6,6 +7,7 @@ const toc = require("./toc");
 
 const TOC_MIN_HEADERS = 2;
 const COLLAPSE_CHILD_PAGES = 8;
+const PREVIEW_LENGTH_CHARS = 100;
 
 const topLevelTopics = [
   ["/blam/tags", "Tags"],
@@ -24,6 +26,8 @@ const wrapper = (page, metaIndex, body) => {
 
   const showToc = page.toc !== undefined ? page.toc : page._headers.length > TOC_MIN_HEADERS;
 
+  const plaintextPreview = `${renderMarkdown(page._md, metaIndex, true).substring(0, PREVIEW_LENGTH_CHARS)}...`;
+
   return html`
     <!DOCTYPE html>
     <html lang="en">
@@ -36,6 +40,7 @@ const wrapper = (page, metaIndex, body) => {
         <meta property="og:type" content="website"/>
         <meta property="og:locale" content="en_US"/>
         <meta property="og:url" content="${metaIndex.baseUrl}${page._path}"/>
+        <meta property="og:description" content="${plaintextPreview}"/>
         <meta property="og:image" content="${imgAbsoluteUrl}"/>
         <title>${page.title} - c20</title>
         <link rel="icon" type="image/png" href="/assets/librarian.png">


### PR DESCRIPTION
Adds the `og:description` opengraph content to page headers. This provides a short preview of page content when links are shared to opengraph-capable social networking services like discord and facebook.

The change mainly consists of adding an alternate markdown renderer which outputs plaintext. Not only is this useful for this PR, but it will be useful for building a search index in the future.

<img width="1016" alt="ogdesc" src="https://user-images.githubusercontent.com/1519264/80643195-88610b00-8a1c-11ea-802f-fff1435be2e4.png">
