### PR TITLE
Add site search

### DIFF
--- a/build-config.json
+++ b/build-config.json
@@ -6,10 +6,14 @@
     "srcResources": "./src/content/**/*.@(jpg|jpeg|png|gif)",
     "srcDiagrams": "./src/content/**/*.@(dot|neato|fdp|sfdp|twopi|circo)",
     "srcContentBase": "./src/content",
-    "srcStaticAssets": "./src/@(assets)/**/*.@(jpg|jpeg|png|gif|ttf)",
+    "srcStaticAssets": "./src/@(assets)/**/*.@(jpg|jpeg|png|gif|ttf|js)",
     "srcStyleEntry": "./src/assets/style.scss",
     "srcStylesAny": "./src/assets/**/*.scss",
-    "vendorAssets": ["./node_modules/highlight.js/styles/atom-one-dark.css"],
+    "vendorAssets": [
+      "./node_modules/highlight.js/styles/atom-one-dark.css",
+      "./node_modules/preact/dist/preact.js",
+      "./node_modules/minisearch/dist/umd/index.js"
+    ],
     "invaderDefsDir": "./lib/invader/src/tag/hek/definition/"
   },
   "baseUrl": "https://c20.reclaimers.net"

--- a/build-config.json
+++ b/build-config.json
@@ -11,8 +11,8 @@
     "srcStylesAny": "./src/assets/**/*.scss",
     "vendorAssets": [
       "./node_modules/highlight.js/styles/atom-one-dark.css",
-      "./node_modules/preact/dist/preact.js",
-      "./node_modules/minisearch/dist/umd/index.js"
+      "./node_modules/@(htm)/preact/standalone.umd.js",
+      "./node_modules/@(minisearch)/dist/umd/index.js"
     ],
     "invaderDefsDir": "./lib/invader/src/tag/hek/definition/"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3109,6 +3109,11 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
+    "minisearch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-2.3.1.tgz",
+      "integrity": "sha512-ZDKpx909JJQUftm85C5YQX0xMsG7jFRfTWGuFG8w/bvmxyhXZlwnY9nFKlMrXCZ9054Qha1DYW1L7N2WQE4pdQ=="
+    },
     "mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -3505,6 +3510,11 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
+    },
+    "preact": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.4.1.tgz",
+      "integrity": "sha512-WKrRpCSwL2t3tpOOGhf2WfTpcmbpxaWtDbdJdKdjd0aEiTkvOmS4NBkG6kzlaAHI9AkQ3iVqbFWM3Ei7mZ4o1Q=="
     },
     "pretty-hrtime": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2459,6 +2459,11 @@
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
     },
+    "htm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.0.4.tgz",
+      "integrity": "sha512-VRdvxX3tmrXuT/Ovt59NMp/ORMFi4bceFMDjos1PV4E0mV+5votuID8R60egR9A4U8nLt238R/snlJGz3UYiTQ=="
+    },
     "html-entities": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.1.tgz",
@@ -3510,11 +3515,6 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
-    },
-    "preact": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.4.1.tgz",
-      "integrity": "sha512-WKrRpCSwL2t3tpOOGhf2WfTpcmbpxaWtDbdJdKdjd0aEiTkvOmS4NBkG6kzlaAHI9AkQ3iVqbFWM3Ei7mZ4o1Q=="
     },
     "pretty-hrtime": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   "homepage": "https://c20.reclaimers.net",
   "dependencies": {
     "express": "^4.17.1",
+    "minisearch": "^2.3.1",
+    "preact": "^10.4.1",
     "serve-static": "^1.14.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "homepage": "https://c20.reclaimers.net",
   "dependencies": {
     "express": "^4.17.1",
+    "htm": "^3.0.4",
     "minisearch": "^2.3.1",
-    "preact": "^10.4.1",
     "serve-static": "^1.14.1"
   },
   "devDependencies": {

--- a/src/assets/main.js
+++ b/src/assets/main.js
@@ -1,0 +1,17 @@
+function setupSearch(indexJson) {
+  var searchIndex = MiniSearch.loadJSON(indexJson, {
+    idField: "path",
+    fields: ["title", "text"],
+    storeFields: ["title"],
+    searchOptions: {
+      boost: {title: 2},
+      fuzzy: 0.2
+    }
+  });
+  var result = searchIndex.search("collision");
+  console.log(result);
+}
+
+fetch("/assets/search-index.json")
+  .then(res => res.text())
+  .then(setupSearch);

--- a/src/assets/main.js
+++ b/src/assets/main.js
@@ -1,30 +1,66 @@
 const {html, render, Component} = htmPreact;
 
-const MAX_SEARCH_SUGGESTIONS = 1;
-
 class Search extends Component {
   constructor() {
     super();
-    this.state = {disabled: true, searchResults: [], suggestions: []};
     this.handleChange = this.handleChange.bind(this);
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.state = {
+      disabled: true,
+      query: "",
+      searchResults: [],
+      selectedResultIndex: -1
+    };
   }
-  handleChange(e) {
-    if (!this.state.disabled) {
-      const query = e.target.value;
-      const searchResults = this.searchIndex.search(query);
-      const suggestions = new Set();
-      this.searchIndex.autoSuggest(query).forEach(s => {
-        if (suggestions.size < MAX_SEARCH_SUGGESTIONS) {
-          suggestions.add(s.terms[0]);
-        }
-      });
+
+  handleKeyDown(e) {
+    if (e.key == "Escape") {
       this.setState({
+        query: "",
+        searchResults: [],
+        selectedResultIndex: -1
+      });
+      if (this.inputRef) {
+        this.inputRef.blur();
+      }
+    } else if (e.key == "ArrowDown") {
+      this.setState({selectedResultIndex: Math.min(
+        this.state.selectedResultIndex + 1,
+        this.state.searchResults.length - 1
+      )});
+    } else if (e.key == "ArrowUp") {
+      this.setState({selectedResultIndex: Math.max(
+        this.state.selectedResultIndex - 1,
+        -1
+      )});
+    } else if (e.key == "Enter") {
+      if (this.state.selectedResultIndex != -1) {
+        window.location = this.state.searchResults[this.state.selectedResultIndex].id;
+      }
+    }
+  }
+
+  handleChange(query) {
+    if (!this.state.disabled) {
+      let searchResults = this.searchIndex.search(query);
+
+      //if no results, try suggested search instead
+      if (searchResults.length == 0) {
+        const suggestions = this.searchIndex.autoSuggest(query);
+        if (suggestions.length > 0) {
+          const firstSuggestionTerm = suggestions[0].terms[0];
+          searchResults = this.searchIndex.search(firstSuggestionTerm);
+        }
+      }
+
+      this.setState({
+        query,
         searchResults,
-        suggestions: [...suggestions],
-        nonempty: !!query
+        selectedResultIndex: -1
       });
     }
   }
+
   componentDidMount() {
     fetch("/assets/search-index.json")
       .then(res => res.text())
@@ -40,31 +76,41 @@ class Search extends Component {
         });
         this.setState({disabled: false});
       });
+    window.addEventListener("keydown", (e) => {
+      if (e.key == "s" && this.inputRef && document.activeElement !== this.inputRef) {
+        this.inputRef.focus();
+        e.preventDefault();
+      }
+    });
   }
+
   render() {
     return html`
       <input
-        class="search-input ${this.state.nonempty ? "nonempty" : ""}"
+        ref=${(el) => this.inputRef = el}
+        class="search-input ${!!this.state.query ? "nonempty" : ""}"
         type="text"
-        list="c20-search-suggestions"
         placeholder="Search c20..."
         disabled=${this.state.disabled}
-        onInput=${this.handleChange}
+        value=${this.state.query}
+        onInput=${(e) => this.handleChange(e.target.value)}
+        onKeyDown=${this.handleKeyDown}
       />
-      <datalist id="c20-search-suggestions">
-        ${this.state.suggestions.map(suggestion => html`
-          <option value=${suggestion}/>
-        `)}
-      </datalist>
-      ${this.state.searchResults.length > 0 && html`
-        <div class="search-results">
+      ${this.state.query != "" && html`
+        <nav class="search-results">
+          <button class="clear-button" onClick=${() => this.handleChange("")}>Close</button>
           <h1>Search results</h1>
-          <ul>
-            ${this.state.searchResults.map(result =>
-              html`<li><a href=${result.id}>${result.title}</a></li>`
-            )}
-          </ul>
-        </div>
+          ${this.state.searchResults.length > 0 ? html`
+            <ul>
+              ${this.state.searchResults.map((result, i) => {
+                const isSelected = i == this.state.selectedResultIndex;
+                return html`<li class=${isSelected ? "selected" : ""}><a href=${result.id}>${result.title}</a></li>`
+              })}
+            </ul>
+          ` : html`
+            <p>No results found for <strong>${this.state.query}</strong></p>
+          `}
+        </nav>
       `}
     `;
   }

--- a/src/assets/main.js
+++ b/src/assets/main.js
@@ -28,11 +28,13 @@ class Search extends Component {
         this.state.selectedResultIndex + 1,
         this.state.searchResults.length - 1
       )});
+      e.preventDefault(); //prevent moving the cursor right in the input
     } else if (e.key == "ArrowUp") {
       this.setState({selectedResultIndex: Math.max(
         this.state.selectedResultIndex - 1,
         -1
       )});
+      e.preventDefault(); //prevent moving the cursor left in the input
     } else if (e.key == "Enter") {
       if (this.state.selectedResultIndex != -1) {
         window.location = this.state.searchResults[this.state.selectedResultIndex].id;

--- a/src/assets/main.js
+++ b/src/assets/main.js
@@ -1,17 +1,54 @@
-function setupSearch(indexJson) {
-  var searchIndex = MiniSearch.loadJSON(indexJson, {
-    idField: "path",
-    fields: ["title", "text"],
-    storeFields: ["title"],
-    searchOptions: {
-      boost: {title: 2},
-      fuzzy: 0.2
+const {html, render, Component} = htmPreact;
+
+class Search extends Component {
+  constructor() {
+    super();
+    this.state = {disabled: true, searchResults: []};
+    this.handleChange = this.handleChange.bind(this);
+  }
+  handleChange(e) {
+    if (!this.state.disabled) {
+      const searchResults = this.searchIndex.search(e.target.value);
+      this.setState({searchResults});
     }
-  });
-  var result = searchIndex.search("collision");
-  console.log(result);
+  }
+  componentDidMount() {
+    fetch("/assets/search-index.json")
+      .then(res => res.text())
+      .then(indexJson => {
+        this.searchIndex = MiniSearch.loadJSON(indexJson, {
+          idField: "path",
+          fields: ["title", "text"],
+          storeFields: ["title"],
+          searchOptions: {
+            boost: {title: 2},
+            fuzzy: 0.2
+          }
+        });
+        this.setState({disabled: false});
+      });
+  }
+  render(props, state) {
+    console.log(this.state.searchResults);
+    return html`
+      <input
+        class="search"
+        type="text"
+        placeholder="Search c20..."
+        disabled=${this.state.disabled}
+        onInput=${this.handleChange}
+      />
+      ${this.state.searchResults.length > 0 && html`
+        <div class="search-results">
+          <ul>
+            ${this.state.searchResults.map(result =>
+              html`<li><a href=${result.id}>${result.title}</a></li>`
+            )}
+          </ul>
+        </div>
+      `}
+    `;
+  }
 }
 
-fetch("/assets/search-index.json")
-  .then(res => res.text())
-  .then(setupSearch);
+render(html`<${Search}/>`, document.getElementById("c20-search-mountpoint"));

--- a/src/assets/main.js
+++ b/src/assets/main.js
@@ -1,15 +1,28 @@
 const {html, render, Component} = htmPreact;
 
+const MAX_SEARCH_SUGGESTIONS = 1;
+
 class Search extends Component {
   constructor() {
     super();
-    this.state = {disabled: true, searchResults: []};
+    this.state = {disabled: true, searchResults: [], suggestions: []};
     this.handleChange = this.handleChange.bind(this);
   }
   handleChange(e) {
     if (!this.state.disabled) {
-      const searchResults = this.searchIndex.search(e.target.value);
-      this.setState({searchResults});
+      const query = e.target.value;
+      const searchResults = this.searchIndex.search(query);
+      const suggestions = new Set();
+      this.searchIndex.autoSuggest(query).forEach(s => {
+        if (suggestions.size < MAX_SEARCH_SUGGESTIONS) {
+          suggestions.add(s.terms[0]);
+        }
+      });
+      this.setState({
+        searchResults,
+        suggestions: [...suggestions],
+        nonempty: !!query
+      });
     }
   }
   componentDidMount() {
@@ -21,25 +34,31 @@ class Search extends Component {
           fields: ["title", "text"],
           storeFields: ["title"],
           searchOptions: {
-            boost: {title: 2},
+            boost: {title: 3, keywords: 2},
             fuzzy: 0.2
           }
         });
         this.setState({disabled: false});
       });
   }
-  render(props, state) {
-    console.log(this.state.searchResults);
+  render() {
     return html`
       <input
-        class="search"
+        class="search-input ${this.state.nonempty ? "nonempty" : ""}"
         type="text"
+        list="c20-search-suggestions"
         placeholder="Search c20..."
         disabled=${this.state.disabled}
         onInput=${this.handleChange}
       />
+      <datalist id="c20-search-suggestions">
+        ${this.state.suggestions.map(suggestion => html`
+          <option value=${suggestion}/>
+        `)}
+      </datalist>
       ${this.state.searchResults.length > 0 && html`
         <div class="search-results">
+          <h1>Search results</h1>
           <ul>
             ${this.state.searchResults.map(result =>
               html`<li><a href=${result.id}>${result.title}</a></li>`

--- a/src/assets/main.js
+++ b/src/assets/main.js
@@ -111,6 +111,7 @@ class Search extends Component {
         <nav class="search-results">
           <button class="clear-button" onClick=${clearInput}>Close</button>
           <h1>Search results</h1>
+          <p class="desktop-only"><small>Hotkeys: <kbd>s</kbd> to search, <kbd>Up/Down</kbd> to choose result, <kbd>Enter</kbd> to select, <kbd>Esc</kbd> to close.</small></p>
           ${this.state.searchResults.length > 0 ? html`
             <ul>
               ${this.state.searchResults.map((result, i) => {

--- a/src/assets/main.js
+++ b/src/assets/main.js
@@ -76,35 +76,48 @@ class Search extends Component {
         });
         this.setState({disabled: false});
       });
+
     window.addEventListener("keydown", (e) => {
+      //check for global keydown of "s" to move focus to the search input
       if (e.key == "s" && this.inputRef && document.activeElement !== this.inputRef) {
         this.inputRef.focus();
+        //prevents event from being passed to next handlers to avoid "s" being put in now-focused input
         e.preventDefault();
       }
     });
   }
 
   render() {
+    const clearInput = () => this.handleChange("");
+    const handleInput = (e) => this.handleChange(e.target.value);
+    const isNonEmptyQuery = this.state.query && this.state.query != "";
+    //save a reference to the DOM element which gets rendered, so we can focus it later
+    const saveInputRef = (el) => this.inputRef = el;
+
     return html`
       <input
-        ref=${(el) => this.inputRef = el}
-        class="search-input ${!!this.state.query ? "nonempty" : ""}"
+        ref=${saveInputRef}
+        class="search-input ${isNonEmptyQuery ? "nonempty" : ""}"
         type="text"
         placeholder="Search c20..."
         disabled=${this.state.disabled}
         value=${this.state.query}
-        onInput=${(e) => this.handleChange(e.target.value)}
+        onInput=${handleInput}
         onKeyDown=${this.handleKeyDown}
       />
-      ${this.state.query != "" && html`
+      ${isNonEmptyQuery && html`
         <nav class="search-results">
-          <button class="clear-button" onClick=${() => this.handleChange("")}>Close</button>
+          <button class="clear-button" onClick=${clearInput}>Close</button>
           <h1>Search results</h1>
           ${this.state.searchResults.length > 0 ? html`
             <ul>
               ${this.state.searchResults.map((result, i) => {
+                //render each search result, ensuring that the user's selected one gets highlighted by CSS:
                 const isSelected = i == this.state.selectedResultIndex;
-                return html`<li class=${isSelected ? "selected" : ""}><a href=${result.id}>${result.title}</a></li>`
+                return html`
+                  <li class=${isSelected ? "selected" : ""}>
+                    <a href=${result.id}>${result.title}</a>
+                  </li>`;
               })}
             </ul>
           ` : html`

--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -126,6 +126,10 @@ input {
   }
 }
 
+small {
+  color: $fg-faded;
+}
+
 hr {
   border: none;
   border-bottom: 1px solid $border-color;
@@ -449,6 +453,10 @@ table {
 @media all and (max-width: 45em) {
   .top-header {
     padding: $padding-containers-small;
+  }
+
+  .desktop-only {
+    display: none;
   }
 
   .content-layout {

--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -268,6 +268,13 @@ table {
       margin-left: 1em;
     }
   }
+
+  .search-results {
+    position: absolute;
+    background: $bg-overlay;
+    border: 1px solid $border-color;
+    padding: $padding-containers;
+  }
 }
 
 .content-sidebar {

--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -9,7 +9,6 @@ $fg: #ccc;
 $fg-faded: #888;
 $fg-strong: #eee;
 $fg-link: #4fbdff;
-$fg-link-visited: #ba9bdf;
 $border-color: #39434d;
 $border-color-header: #184851;
 $border-radius: 2px;
@@ -99,6 +98,10 @@ input {
   padding: $padding-containers-small;
   font-size: $font-size;
   color: $fg;
+
+  &:focus {
+    box-shadow: 0px 0px $padding-containers-small rgba($bg-info, 0.6) inset;
+  }
 
   &:disabled {
     cursor: not-allowed;
@@ -252,11 +255,32 @@ table {
     color: $fg;
   }
 
+  #c20-search-mountpoint {
+    flex-grow: 1;
+    position: relative;
+  }
+
   .c20-name-short {
     display: none;
   }
   .c20-name-long {
     display: inline-block;
+  }
+
+  .search-input {
+    transition: width $transition-time;
+    width: 60%;
+    &:focus, &.nonempty {
+      width: 100%;
+    }
+  }
+
+  .search-results {
+    width: 100%;
+    position: absolute;
+    background: $bg-overlay;
+    border: 1px solid $border-color;
+    padding: $padding-containers;
   }
 
   .c20-top-nav {
@@ -267,13 +291,6 @@ table {
     a {
       margin-left: 1em;
     }
-  }
-
-  .search-results {
-    position: absolute;
-    background: $bg-overlay;
-    border: 1px solid $border-color;
-    padding: $padding-containers;
   }
 }
 
@@ -378,7 +395,7 @@ table {
 }
 
 //mobile view
-@media all and (max-width: 40em) {
+@media all and (max-width: 45em) {
   .top-header {
     padding: $padding-containers-small;
   }
@@ -394,6 +411,10 @@ table {
     }
     .c20-name-long {
       display: none;
+    }
+
+    .search-input {
+      width: 100%;
     }
   }
 }

--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -11,7 +11,7 @@ $fg-strong: #eee;
 $fg-link: #4fbdff;
 $border-color: #39434d;
 $border-color-header: #184851;
-$border-radius: 2px;
+$border-radius: 4px;
 $padding-containers: 20px;
 $padding-flow: 16px;
 $padding-containers-small: 10px;
@@ -90,6 +90,19 @@ h3 {font-size: 1.17em;}
 h4 {font-size: 1.00em;}
 h5 {font-size: 0.83em;}
 h6 {font-size: 0.75em;}
+
+button {
+  background: $bg-inset;
+  color: $fg;
+  border-radius: $border-radius;
+  border: 1px solid $border-color;
+  padding: $padding-containers-small 1em;
+
+  &:hover {
+    background: $bg-overlay;
+    cursor: pointer;
+  }
+}
 
 input {
   border-radius: $border-radius;
@@ -255,11 +268,6 @@ table {
     color: $fg;
   }
 
-  #c20-search-mountpoint {
-    flex-grow: 1;
-    position: relative;
-  }
-
   .c20-name-short {
     display: none;
   }
@@ -267,11 +275,23 @@ table {
     display: inline-block;
   }
 
+  #c20-search-mountpoint {
+    flex-grow: 1;
+    position: relative;
+  }
+
+  .clear-button {
+    float: right;
+    margin-top: $padding-flow;
+    margin-left: $padding-flow;
+  }
+
   .search-input {
     transition: width $transition-time;
     width: 60%;
     &:focus, &.nonempty {
       width: 100%;
+      border-radius: $border-radius $border-radius 0 0;
     }
   }
 
@@ -280,7 +300,38 @@ table {
     position: absolute;
     background: $bg-overlay;
     border: 1px solid $border-color;
-    padding: $padding-containers;
+    border-top: none;
+    border-radius: 0 0 $border-radius $border-radius;
+    padding: 0 $padding-containers;
+    display: flow-root;
+
+    ul {
+      list-style: none;
+      margin: 0 0 $padding-containers 0;
+      padding: 0;
+    }
+
+    li {
+      border: 1px solid $border-color;
+      border-top: none;
+      padding: $padding-containers-small;
+      padding-bottom: $padding-containers-small - 2px;
+
+      &:first-child {
+        border-top: 1px solid $border-color;
+        border-top-left-radius: $border-radius;
+        border-top-right-radius: $border-radius;
+      }
+
+      &:last-child {
+        border-bottom-left-radius: $border-radius;
+        border-bottom-right-radius: $border-radius;
+      }
+
+      &.selected {
+        background: $bg-info;
+      }
+    }
   }
 
   .c20-top-nav {

--- a/src/content.js
+++ b/src/content.js
@@ -164,7 +164,8 @@ async function renderContent(metaIndex, outputDir) {
     fields: ["title", "text", "keywords"],
     storeFields: ["title"],
     processTerm: (term, _fieldName) => {
-      return STOP_WORDS.indexOf(term) == -1 ? term.toLowerCase() : null
+      term = term.toLowerCase();
+      return STOP_WORDS.indexOf(term) == -1 ? term : null
     },
     searchOptions: {
       boost: {title: 3, keywords: 2},

--- a/src/content/blam/tags/fog/readme.md
+++ b/src/content/blam/tags/fog/readme.md
@@ -3,6 +3,8 @@ title: fog
 template: tag
 img: fog.jpg
 imgCaption: "A fog plane exists under Gephyrophobia's bridge"
+keywords:
+  - plane
 ---
 
 Fog tags describe a layer of fog related to _fog planes_ in the [BSP][scenario_structure_bsp]. The tag can be used to adjust colour and density properties.

--- a/src/content/blam/tags/gbxmodel/readme.md
+++ b/src/content/blam/tags/gbxmodel/readme.md
@@ -2,7 +2,6 @@
 title: gbxmodel
 template: tag
 stub: true
-tagClass: GBXModel
 ---
 
 The Gearbox model tag contains the render model and [shader_model][] references for [objects][object] such as [vehicles][vehicle], [scenery][], and [weapons][weapon] among others. It is not collideable nor animated on its own, and objects may reference additional [model_collision_geometry][] and [model_animations][] tags.

--- a/src/content/blam/tags/scenario_structure_bsp/readme.md
+++ b/src/content/blam/tags/scenario_structure_bsp/readme.md
@@ -3,7 +3,14 @@ title: scenario_structure_bsp
 template: tag
 img: bsp.jpg
 imgCaption: The map a30's BSP with all objects removed using `object_destroy_all`
-tagClass: ScenarioStructureBSP
+keywords:
+  - lightmap
+  - radiosity
+  - cluster
+  - plane
+  - weather
+  - polyhedra
+  - bsp
 ---
 
 Commonly referred to as the **BSP**, this tag contains level geometry, weather data, material assignments, AI pathfinding information, lightmaps, and other data structures. The name "BSP" is commonly used to refer to non-[object][] level geometry in general. Aside from sounds and [bitmaps][bitmap], the BSP tends to be one of the largest tags in a map.

--- a/src/content/readme.md
+++ b/src/content/readme.md
@@ -1,6 +1,5 @@
 ---
 title: The Reclaimers Library
-template: home
 ---
 
 Welcome to **c20**, a project which aims to document the immense tribal knowledge of the [Halo 1][h1] modding community, focusing primarily on _Halo: Custom Edition_. C20 will cover [engine details][blam], the [Halo Editing Kit][hek], community tools, and guides for custom content creation.

--- a/src/templates/default.js
+++ b/src/templates/default.js
@@ -1,5 +1,15 @@
 const {wrapper, renderMarkdown, html} = require("./shared");
 
-module.exports = (page, metaIndex) => wrapper(page, metaIndex, html`
-  ${renderMarkdown(page._md, metaIndex)}
-`);
+module.exports = (page, metaIndex) => {
+  const htmlDoc = wrapper(page, metaIndex, html`
+    ${renderMarkdown(page._md, metaIndex)}
+  `);
+
+  const searchDoc = {
+    path: page._path,
+    title: page.title,
+    text: renderMarkdown(page._md, metaIndex, true)
+  };
+
+  return {htmlDoc, searchDoc};
+}

--- a/src/templates/default.js
+++ b/src/templates/default.js
@@ -8,7 +8,8 @@ module.exports = (page, metaIndex) => {
   const searchDoc = {
     path: page._path,
     title: page.title,
-    text: renderMarkdown(page._md, metaIndex, true)
+    text: renderMarkdown(page._md, metaIndex, true),
+    keywords: (page.keywords || []).join(" ")
   };
 
   return {htmlDoc, searchDoc};

--- a/src/templates/home.js
+++ b/src/templates/home.js
@@ -1,6 +1,0 @@
-const {wrapper, ul, pageAnchor, renderMarkdown, html} = require("./shared");
-
-module.exports = (page, metaIndex) => wrapper(page, metaIndex, html`
-  ${renderMarkdown(page._md, metaIndex)}
-  ${ul(metaIndex.pages.map((page) => pageAnchor(page)))}
-`);

--- a/src/templates/index.js
+++ b/src/templates/index.js
@@ -1,5 +1,4 @@
 module.exports = {
-  home: require("./home"),
   tag: require("./tag"),
   tagIndex: require("./tagIndex"),
   tool: require("./tool"),

--- a/src/templates/shared/breadcrumbs.js
+++ b/src/templates/shared/breadcrumbs.js
@@ -1,12 +1,18 @@
 const {ol, pageAnchor, escapeHtml} = require("./bits");
 
+const HOME_TITLE_OVERRIDE = "Home";
+
 const breadcrumbs = (page, metaIndex) => {
-  const breadcrumbs = [page];
+  const breadcrumbs = [];
   let currPage = page;
 
-  while (currPage._parent) {
-    breadcrumbs.push(currPage._parent);
+  while (currPage) {
+    breadcrumbs.push(currPage._parent ? currPage : {...currPage, title: HOME_TITLE_OVERRIDE});
     currPage = currPage._parent;
+  }
+
+  if (breadcrumbs.length < 2) {
+    return null;
   }
 
   return ol(breadcrumbs.reverse().map((crumbPage, i) =>

--- a/src/templates/shared/footer.js
+++ b/src/templates/shared/footer.js
@@ -10,8 +10,8 @@ const footer = (page, metaIndex) => {
         <small>
           This text is available under the <a href="${LICENSE_URL}">CC BY-SA 3.0 license</a>
           •
-          ${metaIndex.packageVersion && `
-            c20 v${metaIndex.packageVersion}
+          ${metaIndex.packageVersion && html`
+            <a href="${REPO_URL}">c20 v${metaIndex.packageVersion}</a>
           `}
           •
           <a href="${srcUrl}">Source</a>

--- a/src/templates/shared/header.js
+++ b/src/templates/shared/header.js
@@ -7,7 +7,7 @@ const header = () => html`
       <span class="c20-name-long">The Reclaimers Library</span>
     </a>
     <nav class="c20-top-nav">
-      <input type="text" class="search" disabled placeholder="Search not implemented"></input>
+      <div id="c20-search-mountpoint"></div>
       <a href="${DISCORD_URL}">Discord</a>
       <a href="${REPO_URL}">Contribute</a>
     </nav>

--- a/src/templates/shared/header.js
+++ b/src/templates/shared/header.js
@@ -1,4 +1,4 @@
-const {html, DISCORD_URL, REPO_URL} = require("./bits");
+const {html, DISCORD_URL} = require("./bits");
 
 const header = () => html`
   <header class="top-header">
@@ -6,10 +6,9 @@ const header = () => html`
       <span class="c20-name-short">c20</span>
       <span class="c20-name-long">The Reclaimers Library</span>
     </a>
+    <div id="c20-search-mountpoint"></div>
     <nav class="c20-top-nav">
-      <div id="c20-search-mountpoint"></div>
       <a href="${DISCORD_URL}">Discord</a>
-      <a href="${REPO_URL}">Contribute</a>
     </nav>
   </header>
 `;

--- a/src/templates/shared/wrapper.js
+++ b/src/templates/shared/wrapper.js
@@ -43,6 +43,7 @@ const wrapper = (page, metaIndex, body) => {
         <meta property="og:description" content="${plaintextPreview}"/>
         <meta property="og:image" content="${imgAbsoluteUrl}"/>
         <title>${page.title} - c20</title>
+        <link rel="preload" type="application/json" as="fetch" href="/assets/search-index.json">
         <link rel="icon" type="image/png" href="/assets/librarian.png">
         <link rel="stylesheet" href="/assets/style.css"/>
         <link rel="stylesheet" href="/assets/atom-one-dark.css"/>
@@ -62,6 +63,10 @@ const wrapper = (page, metaIndex, body) => {
               `) : (
                 ul(page._childPages.map(pageAnchor))
               )}
+            `}
+            ${page._relatedPages.length > 0 && html`
+              <h2>Related pages</h2>
+              ${ul(page._relatedPages.map(pageAnchor))}
             `}
             <h2>Main topics</h2>
             ${ul(topLevelTopics.map(topic => anchor(...topic)))}

--- a/src/templates/shared/wrapper.js
+++ b/src/templates/shared/wrapper.js
@@ -78,6 +78,8 @@ const wrapper = (page, metaIndex, body) => {
           </main>
           ${footer(page, metaIndex)}
         </div>
+        <script src="/assets/index.js"></script>
+        <script src="/assets/main.js"></script>
       </body>
     </html>
   `;

--- a/src/templates/shared/wrapper.js
+++ b/src/templates/shared/wrapper.js
@@ -78,7 +78,8 @@ const wrapper = (page, metaIndex, body) => {
           </main>
           ${footer(page, metaIndex)}
         </div>
-        <script src="/assets/index.js"></script>
+        <script src="/assets/minisearch/dist/umd/index.js"></script>
+        <script src="/assets/htm/preact/standalone.umd.js"></script>
         <script src="/assets/main.js"></script>
       </body>
     </html>

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -89,7 +89,7 @@ module.exports = (page, metaIndex) => {
     ]
   };
 
-  return wrapper(pageMetaForWrapper, metaIndex, html`
+  const htmlDoc = wrapper(pageMetaForWrapper, metaIndex, html`
     ${metabox(metaboxOpts)}
     ${tag.unused && alert("danger", html`
       <p>
@@ -108,4 +108,12 @@ module.exports = (page, metaIndex) => {
       `)}
     `}
   `);
+
+  const searchDoc = {
+    path: page._path,
+    title: page.title,
+    text: renderMarkdown(page._md, metaIndex, true)
+  };
+
+  return {htmlDoc, searchDoc};
 };

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -112,7 +112,8 @@ module.exports = (page, metaIndex) => {
   const searchDoc = {
     path: page._path,
     title: page.title,
-    text: renderMarkdown(page._md, metaIndex, true)
+    text: renderMarkdown(page._md, metaIndex, true),
+    keywords: (page.keywords || []).join(" ")
   };
 
   return {htmlDoc, searchDoc};

--- a/src/templates/tagIndex.js
+++ b/src/templates/tagIndex.js
@@ -38,7 +38,7 @@ module.exports = (page, metaIndex) => {
     ]
   };
 
-  return wrapper(pageMetaForWrapper, metaIndex, html`
+  const htmlDoc = wrapper(pageMetaForWrapper, metaIndex, html`
     ${renderMarkdown(page._md, metaIndex)}
     ${heading("h1", "Tags list")}
     ${tagsTable(metaIndex.data.h1.tags.filter(t => !t.unused), metaIndex)}
@@ -50,4 +50,12 @@ module.exports = (page, metaIndex) => {
     </p>
     ${tagsTable(metaIndex.data.h1.tags.filter(t => t.unused), metaIndex)}
   `);
+
+  const searchDoc = {
+    path: page._path,
+    title: page.title,
+    text: renderMarkdown(page._md, metaIndex, true)
+  };
+
+  return {htmlDoc, searchDoc};
 };

--- a/src/templates/tagIndex.js
+++ b/src/templates/tagIndex.js
@@ -54,7 +54,8 @@ module.exports = (page, metaIndex) => {
   const searchDoc = {
     path: page._path,
     title: page.title,
-    text: renderMarkdown(page._md, metaIndex, true)
+    text: renderMarkdown(page._md, metaIndex, true),
+    keywords: (page.keywords || []).join(" ")
   };
 
   return {htmlDoc, searchDoc};

--- a/src/templates/tool.js
+++ b/src/templates/tool.js
@@ -19,7 +19,8 @@ module.exports = (page, metaIndex) => {
   const searchDoc = {
     path: page._path,
     title: page.title,
-    text: renderMarkdown(page._md, metaIndex, true)
+    text: renderMarkdown(page._md, metaIndex, true),
+    keywords: (page.keywords || []).join(" ")
   };
 
   return {htmlDoc, searchDoc};

--- a/src/templates/tool.js
+++ b/src/templates/tool.js
@@ -11,8 +11,16 @@ module.exports = (page, metaIndex) => {
     ]
   };
 
-  return wrapper(page, metaIndex, html`
+  const htmlDoc = wrapper(page, metaIndex, html`
     ${metabox(metaboxOpts)}
     ${renderMarkdown(page._md, metaIndex)}
   `);
+
+  const searchDoc = {
+    path: page._path,
+    title: page.title,
+    text: renderMarkdown(page._md, metaIndex, true)
+  };
+
+  return {htmlDoc, searchDoc};
 };


### PR DESCRIPTION
Implements the site-wide search feature in the top nav bar. Changes made:

* At build time, create a serializable search index
* Add a main JS file which loads for each page the user visits. This loads the search index and handles the interactivity and rendering of the search feature
* Add new CSS for the search results stuff
* Give pages the ability to specify keywords which are weighted highly in search
* Added a "related pages" feature which links pages via the sidebar when they have overlapping keywords

![tmp](https://user-images.githubusercontent.com/1519264/80925534-5b2a9a80-8d45-11ea-80f7-53e5f2d08684.gif)
