### PR TITLE
Add thanks/acknowledgements feature

### DIFF
--- a/src/content/blam/map/readme.md
+++ b/src/content/blam/map/readme.md
@@ -1,5 +1,8 @@
 ---
 title: Map cache file
+thanks:
+  - to: Masterz1337
+    for: Context on OpenSauce capabilities
 ---
 
 A map, also known as a **cache file**, is a bundle of compiled [tags][] which can be loaded and used by [Halo][h1]. With the exception of _resource maps_, each map represents a playable campaign, multiplayer level, or main menu.

--- a/src/content/blam/tags/bitmap/readme.md
+++ b/src/content/blam/tags/bitmap/readme.md
@@ -3,6 +3,9 @@ title: bitmap
 template: tag
 img: "bitmap_example.jpg"
 imgCaption: A typical level texture bitmap, used for environment shaders
+thanks:
+  - to: gbMichelle
+    for: Information on formats, bitmap types, usage, compilation, and errors
 ---
 
 Bitmaps are used for visuals that need textures or sprites like environments, objects, effects, menus, etc.

--- a/src/content/blam/tags/readme.md
+++ b/src/content/blam/tags/readme.md
@@ -1,6 +1,9 @@
 ---
 title: Tags
 template: tagIndex
+thanks:
+  - to: Kavawuvi
+    for: Information about invalid tags
 ---
 
 <figure>

--- a/src/content/blam/tags/scenario_structure_bsp/readme.md
+++ b/src/content/blam/tags/scenario_structure_bsp/readme.md
@@ -11,6 +11,12 @@ keywords:
   - weather
   - polyhedra
   - bsp
+thanks:
+  - to: MosesOfEgypt
+    for: Research on weather polyhedra and portals
+  - to: Conscars
+    for: Collision BSP structure and phantom BSP research
+
 ---
 
 Commonly referred to as the **BSP**, this tag contains level geometry, weather data, material assignments, AI pathfinding information, lightmaps, and other data structures. The name "BSP" is commonly used to refer to non-[object][] level geometry in general. Aside from sounds and [bitmaps][bitmap], the BSP tends to be one of the largest tags in a map.

--- a/src/content/games/h1/readme.md
+++ b/src/content/games/h1/readme.md
@@ -2,6 +2,13 @@
 title: "Halo: Combat Evolved"
 keywords:
   - halo
+thanks:
+  - to: gbMichelle
+    for: CEA/MCC lineage information
+  - to: Hasuku
+    for: Xbox modding lineage
+  - to: Kavawuvi
+    for: Engine versions
 ---
 
 <figure>

--- a/src/content/thanks/readme.md
+++ b/src/content/thanks/readme.md
@@ -1,0 +1,14 @@
+---
+title: Acknowledgements
+template: thanksIndex
+keywords:
+  - thanks
+  - credits
+  - authors
+---
+
+This website is edited and maintained by [Sigmmma][], comprised of gbMichelle, Mia Moretti, and Conscars. Firstly, we would like to thank Bungie and Gearbox Software for creating this game we love, and releasing the tools that fostered this modding community.
+
+Secondly, much of the community's modding knowledge comes from the hard work of community members who have researched, reverse engineered, experimented, and documented. Our current understanding is built on a mountain of contributions, and while we can't include everyone we would at least like to thank the following people:
+
+[sigmmma]: https://github.com/Sigmmma

--- a/src/data/h1/index.js
+++ b/src/data/h1/index.js
@@ -57,7 +57,11 @@ function buildData(invaderStructDefs) {
     tagsById,
     tagsByName,
     getToolIntegrations,
-    invaderStructDefs
+    invaderStructDefs,
+    tagThanks: [
+      {to: "MosesOfEgypt", for: "Tag structure research"},
+      {to: "Kavawuvi", for: "Invader tag definitions"},
+    ]
   };
 };
 

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -1,8 +1,12 @@
 const buildH1Data = require("./h1");
 
 function buildData(invaderStructDefs) {
+  const h1Data = buildH1Data(invaderStructDefs);
   return {
-    h1: buildH1Data(invaderStructDefs)
+    h1: h1Data,
+    thanks: [
+      ...h1Data.tagThanks
+    ]
   };
 }
 

--- a/src/templates/index.js
+++ b/src/templates/index.js
@@ -2,5 +2,6 @@ module.exports = {
   tag: require("./tag/tag"),
   tagIndex: require("./tagIndex"),
   tool: require("./tool"),
-  default: require("./default")
+  default: require("./default"),
+  thanksIndex: require("./thanksIndex")
 };

--- a/src/templates/shared/thanks.js
+++ b/src/templates/shared/thanks.js
@@ -1,0 +1,25 @@
+const {ul, html, escapeHtml} = require("./bits");
+
+const thanks = (thanks) => {
+  const pageThanksByName = {};
+
+  for (let thank of thanks) {
+    pageThanksByName[thank.to] = pageThanksByName[thank.to] || [];
+    if (thank.for) {
+      pageThanksByName[thank.to].push(thank.for);
+    }
+  }
+  const pageThanks = Object.entries(pageThanksByName);
+  pageThanks.sort(([aTo], [bTo]) => aTo.localeCompare(bTo));
+
+  return html`
+    <h1>Acknowledgements</h1>
+    <p>Thanks to the following individuals for their research or contributions to this topic:</p>
+    ${ul(pageThanks.map(([to, forEntries]) => {
+      const forPart = forEntries.length > 0 ? ` <em>(${escapeHtml(forEntries.join("; "))})</em>` : "";
+      return `${escapeHtml(to)}${forPart}`;
+    }))}
+  `;
+};
+
+module.exports = thanks;

--- a/src/templates/shared/wrapper.js
+++ b/src/templates/shared/wrapper.js
@@ -4,6 +4,7 @@ const footer = require("./footer");
 const header = require("./header");
 const breadcrumbs = require("./breadcrumbs");
 const toc = require("./toc");
+const thanks = require("./thanks");
 
 const TOC_MIN_HEADERS = 2;
 const COLLAPSE_CHILD_PAGES = 8;
@@ -79,6 +80,7 @@ const wrapper = (page, metaIndex, body) => {
               <h1 class="page-title">${escapeHtml(page.title)}</h1>
               ${page.stub && STUB_ALERT}
     ${body}
+    ${page.thanks && thanks(page.thanks)}
             </article>
           </main>
           ${footer(page, metaIndex)}

--- a/src/templates/tag/tag.js
+++ b/src/templates/tag/tag.js
@@ -94,6 +94,10 @@ module.exports = (page, metaIndex) => {
   //because we're adding headers to the page, should update the headers list for ToC
   const pageMetaForWrapper = {
     ...page,
+    thanks: [
+      ...(page.thanks || []),
+      ...metaIndex.data.h1.tagThanks
+    ],
     _headers: [
       ...page._headers,
       ...(!tag.invaderStruct ? [] : [

--- a/src/templates/thanksIndex.js
+++ b/src/templates/thanksIndex.js
@@ -1,0 +1,38 @@
+const {wrapper, renderMarkdown, html, ul} = require("./shared");
+
+module.exports = (page, metaIndex) => {
+  let allThanks = new Set();
+
+  for (let page of metaIndex.pages) {
+    for (let thank of (page.thanks || [])) {
+      if (thank.to) {
+        allThanks.add(thank.to);
+      }
+    }
+  }
+
+  for (let thank of metaIndex.data.thanks) {
+    if (thank.to) {
+      allThanks.add(thank.to);
+    }
+  }
+
+  //convert to an array and sort alphabetically
+  allThanks = [...allThanks];
+  allThanks.sort((a, b) => a.localeCompare(b));
+
+  const htmlDoc = wrapper(page, metaIndex, html`
+    ${renderMarkdown(page._md, metaIndex)}
+    <h2>Thank you!</h2>
+    ${ul(allThanks)}
+  `);
+
+  const searchDoc = {
+    path: page._path,
+    title: page.title,
+    text: renderMarkdown(page._md, metaIndex, true),
+    keywords: (page.keywords || []).join(" ")
+  };
+
+  return {htmlDoc, searchDoc};
+}


### PR DESCRIPTION
Pages (and certain data sources like tag structures) can now specify `thanks` metadata which is rendered as acknowledgements in the page footer and in a site-wide `/thanks` page which aggregates all contributors.

## Screenshots
<img width="777" alt="pr1" src="https://user-images.githubusercontent.com/1519264/83322130-0fff8c80-a20a-11ea-90ba-f5c9ca2273b9.png">
<img width="1023" alt="pr3" src="https://user-images.githubusercontent.com/1519264/83322133-12fa7d00-a20a-11ea-9a83-321532ea0a3b.png">
<img width="853" alt="pr2" src="https://user-images.githubusercontent.com/1519264/83322136-13931380-a20a-11ea-8395-6f9c73778eec.png">
