### PR TITLE
Add source and edit links to top of the article

### DIFF
--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -139,8 +139,19 @@ details {
   margin: $padding-flow 0;
 }
 
-h1.page-title {
-  font-size: 2em;
+.page-title {
+  border-bottom: 1px solid $border-color;
+  margin-bottom: $padding-containers;
+  display: flex;
+  align-content: space-between;
+  align-items: baseline;
+
+  h1 {
+    padding-bottom: 0;
+    font-size: 2em;
+    border-bottom: none;
+    flex-grow: 1;
+  }
 }
 
 a.header-anchor {

--- a/src/templates/shared/footer.js
+++ b/src/templates/shared/footer.js
@@ -3,7 +3,6 @@ const {html, REPO_URL} = require("./bits");
 const LICENSE_URL = "https://creativecommons.org/licenses/by-sa/3.0/";
 
 const footer = (page, metaIndex) => {
-  const srcUrl = `${REPO_URL}/tree/master/src/content${page._path}`;
   return html`
     <footer class="content-footer">
       <p>
@@ -13,8 +12,6 @@ const footer = (page, metaIndex) => {
           ${metaIndex.packageVersion && html`
             <a href="${REPO_URL}">c20 v${metaIndex.packageVersion}</a>
           `}
-          •
-          <a href="${srcUrl}">Source</a>
           •
           <a href="#">Go to top</a>
         </small>

--- a/src/templates/shared/wrapper.js
+++ b/src/templates/shared/wrapper.js
@@ -21,6 +21,8 @@ const STUB_ALERT = alert("danger", html`
 `);
 
 const wrapper = (page, metaIndex, body) => {
+  const editPageUrl = `${REPO_URL}/edit/master/src/content${page._path}/readme.md`;
+  const srcUrl = `${REPO_URL}/tree/master/src/content${page._path}`;
   const imgAbsoluteUrl = page.img ?
     `${metaIndex.baseUrl}${page._path}/${page.img}` :
     `${metaIndex.baseUrl}/assets/librarian.png`;
@@ -77,7 +79,14 @@ const wrapper = (page, metaIndex, body) => {
               ${breadcrumbs(page, metaIndex)}
             </nav>
             <article class="content-article">
-              <h1 class="page-title">${escapeHtml(page.title)}</h1>
+              <div class="page-title">
+                <h1 class="page-title">${escapeHtml(page.title)}</h1>
+                <div class="edit-buttons">
+                  <a href="${srcUrl}">Source</a>
+                  •
+                  <a href="${editPageUrl}">Edit</a>
+                </div>
+              </div>
               ${page.stub && STUB_ALERT}
     ${body}
     ${page.thanks && thanks(page.thanks)}


### PR DESCRIPTION
Replicates the "edit" button seen on the Rust modding wiki in c20:
https://rustmapmaking.github.io/Wiki/Monuments

The user is prompted to fork the c20 repo or can edit it inline if they have permission.

## Screenshot

![pr_000](https://user-images.githubusercontent.com/1519264/83364263-ef901900-a354-11ea-8d01-a3cc1be43ed0.png)
