### PR TITLE
Render primitive tag field types with more detail

### DIFF
--- a/src/content/blam/tags/readme.md
+++ b/src/content/blam/tags/readme.md
@@ -26,7 +26,7 @@ Some tag fields are _references_ to other tags. In tools like [Guerilla][], thes
 When tags are compiled into a map, their references are converted into pre-calculated pointers. An array of tag paths are still retained in the map but is not used by the game.
 
 ## Blocks
-A _tag block_ field, also known as a _reflexive_, is essentially an array header. The field consists of an item count and an internal pointer to an array of structures of an expected type. An example is the [scenario][] tag containing a block of [vehicles][vehicle]. In visual tag editors, blocks appear as a list of elements which are often editable by adding or removing elements.
+A _tag block_ field, also known as a _reflexive_, is essentially a list of smaller data structures within a tag. An example is the [scenario][] tag containing a block of [vehicles][vehicle]. In visual tag editors, blocks appear as a list of elements which are often editable by adding or removing elements. A block field internally consists of an item count and a pointer to an array of structures of the expected type.
 
 ## Engine IDs
 To identity tag types in-engine and within tag data, Halo uses compact fixed-size (4 character) identifiers rather than the longer tag names/extensions seen in the [HEK][]. Some examples include `bitm` for [bitmap][bitmap], `snd!` for [sound][], and `DeLa` for [ui_widget_definition][]. These identifiers are case-sensitive and may be padded with trailing spaces.

--- a/src/templates/tag/primitives.js
+++ b/src/templates/tag/primitives.js
@@ -1,0 +1,114 @@
+const PRIMITIVES = {
+  //basic primitives
+  int8: {name: "i8"},
+  int16: {name: "i16"},
+  int32: {name: "i32"},
+  uint8: {name: "u8"},
+  uint16: {name: "u16"},
+  uint32: {name: "u32"},
+  float: {name: "f32"},
+
+  //primitive aliases
+  Angle: {name: "Angle: f32"},
+  Fraction: {name: "Fraction: f32"},
+  Index: {name: "Index: u16"},
+  Pointer: {name: "Pointer: u32"},
+  TagClassInt: {name: "TagEngineID: char[4]"},
+  TagString: {name: "char[32]"},
+
+  //composite types
+  ColorARGB: {fields: [
+    {name: "alpha", type: "f32"},
+    {name: "red", type: "f32"},
+    {name: "green", type: "f32"},
+    {name: "blue", type: "f32"},
+  ]},
+  ColorARGBInt: {fields: [
+    {name: "alpha", type: "u8"},
+    {name: "red", type: "u8"},
+    {name: "green", type: "u8"},
+    {name: "blue", type: "u8"},
+  ]},
+  ColorRGB: {fields: [
+    {name: "red", type: "f32"},
+    {name: "green", type: "f32"},
+    {name: "blue", type: "f32"},
+  ]},
+  Euler2D: {fields: [
+    {name: "yaw", type: "f32"},
+    {name: "pitch", type: "f32"},
+  ]},
+  Euler3D: {fields: [
+    {name: "yaw", type: "f32"},
+    {name: "pitch", type: "f32"},
+    {name: "roll", type: "f32"},
+  ]},
+  Matrix: {name: "Matrix3x3", fields: [
+    {name: "elements (9)", type: "f32"},
+  ]},
+  Plane2D: {fields: [
+    {name: "i", type: "f32"},
+    {name: "j", type: "f32"},
+    {name: "d", type: "f32"},
+  ]},
+  Plane3D: {fields: [
+    {name: "i", type: "f32"},
+    {name: "j", type: "f32"},
+    {name: "k", type: "f32"},
+    {name: "d", type: "f32"},
+  ]},
+  Point2D: {fields: [
+    {name: "x", type: "f32"},
+    {name: "y", type: "f32"},
+  ]},
+  Point2DInt: {fields: [
+    {name: "x", type: "i16"},
+    {name: "y", type: "i16"},
+  ]},
+  Point3D: {fields: [
+    {name: "x", type: "f32"},
+    {name: "y", type: "f32"},
+    {name: "z", type: "f32"},
+  ]},
+  Quaternion: {fields: [
+    {name: "i", type: "f32"},
+    {name: "j", type: "f32"},
+    {name: "k", type: "f32"},
+    {name: "w", type: "f32"},
+  ]},
+  Rectangle2D: {fields: [
+    {name: "top", type: "i16"},
+    {name: "left", type: "i16"},
+    {name: "bottom", type: "i16"},
+    {name: "right", type: "i16"},
+  ]},
+  TagDataOffset: {fields: [
+    {name: "size", type: "u32"},
+    {name: "external", type: "u32"},
+    {name: "file offset", type: "u32"},
+    {name: "pointer", type: "u64"},
+  ]},
+  TagID: {name: "TagID: union", fields: [
+    {name: "id", type: "u32"},
+    {name: "index", type: "u16"},
+  ]},
+  Vector2D: {fields: [
+    {name: "i", type: "f32"},
+    {name: "j", type: "f32"},
+  ]},
+  Vector3D: {fields: [
+    {name: "i", type: "f32"},
+    {name: "j", type: "f32"},
+    {name: "k", type: "f32"},
+  ]},
+};
+
+//use invader primitive type names to lookup new name and composite fields if available
+module.exports = (invaderTypeName) => {
+  const extraInfo = PRIMITIVES[invaderTypeName];
+  if (extraInfo) {
+    const newTypeName = extraInfo.name || invaderTypeName;
+    return {typeName: newTypeName, compositeFields: extraInfo.fields};
+  }
+  return {typeName: invaderTypeName};
+};

--- a/src/templates/tag/tag.js
+++ b/src/templates/tag/tag.js
@@ -1,4 +1,4 @@
-const {html, wrapper, renderMarkdown, metabox, alert, tagAnchor, ul, heading, detailsList, pageAnchor} = require("../shared");
+const {html, wrapper, defAnchor, renderMarkdown, metabox, alert, tagAnchor, ul, heading, detailsList, pageAnchor} = require("../shared");
 const renderTagStructure = require("./tagStructure");
 
 module.exports = (page, metaIndex) => {
@@ -8,7 +8,7 @@ module.exports = (page, metaIndex) => {
   }
 
   const metaboxHtmlSections = [{
-    body: html`<p>Engine ID<sup><a href="${metaIndex.resolveSlug("tags", "engine-ids")}">?</a></sup>: <code>${tag.id}</code></p>`
+    body: html`<p>Engine ID${defAnchor(metaIndex.resolveSlug("tags", "engine-ids"))}: <code>${tag.id}</code></p>`
   }];
 
   if (tag.parent) {

--- a/src/templates/tag/tagStructure.js
+++ b/src/templates/tag/tagStructure.js
@@ -186,7 +186,7 @@ const structView = (struct, structName, comments, metaIndex, addHeading, hLevel)
           ${struct.fields.map((field, i) => html`
             <tr>
               <td>${field}</td>
-              <td><code title="${i}">0x${(0x1 << i).toString(16)}</code></td>
+              <td><code title="${0x1 << i}">0x${(0x1 << i).toString(16)}</code></td>
               <td>${renderComment(comments.fields.find(it => it.name == field).md, metaIndex)}</td>
             </tr>
           `)}


### PR DESCRIPTION
Currently, primitive tag field types are directly rendered using Invader's name (e.g. `uint32` or `Point3D`). Some "primitive" types like `Plane2D` are actually composite data structures with multiple internal fields, and I also wanted to rename some of Invader's primitive type names like "Matrix" to "Matrix3x3".

This PR adds a lookup table for primitive types which supports renaming and retrieving composite fields. The composite fields are rendered using a `<details>` element which is closed by default:

<img width="474" alt="example1" src="https://user-images.githubusercontent.com/1519264/83940206-b3ffaf80-a797-11ea-9add-5f0fb4748304.png">

Another change in this PR is the addition of base-10 hover titles for bitfield masks and enum values:
_(not the best example because only up to 0x8 but you get the idea)_
<img width="494" alt="example2" src="https://user-images.githubusercontent.com/1519264/83940207-b530dc80-a797-11ea-93fa-b3a360a8e06a.png">
