### PR TITLE
Properly show inherited fields of non-root tag structures

### DIFF
--- a/src/data/h1/invader.js
+++ b/src/data/h1/invader.js
@@ -3,18 +3,24 @@
  */
 
 //for the given struct, get all structs which comprise it
-function expandStructs(struct, structs) {
-  return struct.fields
-    .filter(field => field.type == "TagReflexive" &&
+function expandStructs(struct, structDefs, isRoot) {
+  const results = struct.fields
+    .filter(field =>
+      field.type == "TagReflexive" &&
       field.struct != "PredictedResource"
     )
-    .map(field => structs[field.struct]);
+    .map(field => structDefs[field.struct]);
+  if (!isRoot && struct.inherits) {
+    results.push(structDefs[struct.inherits]);
+  }
+  return results;
 }
 
 //get all tag names (e.g. sound_looping) referenced by the given struct (e.g. SoundScenery)
-function getDirectReferencedTagNames(structName, structs) {
+function getDirectReferencedTagNames(structName, structDefs) {
   const results = new Set();
-  let structStack = [structs[structName]];
+  let structStack = [structDefs[structName]];
+  let isRoot = true;
 
   while (structStack.length > 0) {
     const struct = structStack.pop();
@@ -27,8 +33,9 @@ function getDirectReferencedTagNames(structName, structs) {
       });
     structStack = [
       ...structStack,
-      ...expandStructs(struct, structs)
+      ...expandStructs(struct, structDefs, isRoot)
     ];
+    isRoot = false;
   }
 
   return [...results].sort();


### PR DESCRIPTION
The invader struct definitions reduce duplication by defining some common structs which others can inherit. An example is item inheriting from object. We hide inherited fields in a tag page's structure section to avoid length articles and bloat, but there are also cases where we want to allow struct inheritance. For example, scenario scenery and other scenario sub-structs inherit from `SpawnPrelude`. This PR allows field inheritance when the struct is not a "root level" tag structure. The change is applied to both tag dependency lookups for the metabox and to the structure section.

I have also allowed the YAML comments to be optional and not break the build when we haven't mirrored the tag structure exactly, since there's still lots incomplete around documentation and I'd like to find a better way to document inherited structures rather than copying comments around to each usage.

## Before
![tmp-pr0](https://user-images.githubusercontent.com/1519264/86519413-6eaebc00-bdef-11ea-91dc-43cc8f67bcc8.png)

## After
![tmp-pr](https://user-images.githubusercontent.com/1519264/86519411-6e162580-bdef-11ea-91e5-3e648d77c3b2.png)

