### PR TITLE
Clarify Blam! engine name, add more H1 builds to evolution diagram

### DIFF
--- a/src/content/h1/blam/readme.md
+++ b/src/content/h1/blam/readme.md
@@ -1,9 +1,9 @@
 ---
-title: Blam!
+title: Halo engine (Blam!)
 stub: true
 ---
 
-Blam! is the proprietary game engine powering [Halo][h1]. It was developed in-house at Bungie and has undergone significant evolution over the series' expansion. According to a [Jason Jones interview][jones-interview], the engine has its roots in [Myth][]:
+The **Halo engine**, colloquially called the **Blam! engine** by the community, is the proprietary game engine powering [Halo][h1]. It was developed in-house at Bungie and has undergone significant evolution over the series' expansion. According to a [Jason Jones interview][jones-interview], the engine has its roots in [Myth][]:
 
 > Halo didn't begin as a strategy game but the engine it uses started out that way. The engine Halo uses began as a next-generation Myth terrain engine, with polygonal units.
 
@@ -25,7 +25,7 @@ For resource management, Halo loads [map cache files][map] which contain [tags][
   </figcaption>
 </figure>
 
-The Blam! engine was not just used for the Halo series. Bungie co-founder [Alex Seropian][alex] went on to found [Wideload Games][wideload] and used the engine for [Stubbs the Zombie in Rebel Without a Pulse][stubbs]. In fact, it is possible to extract [tags][] from Stubbs using [Refinery][mek] and recompile levels for Halo.
+The Halo engine was not just used for the Halo series. Bungie co-founder [Alex Seropian][alex] went on to found [Wideload Games][wideload] and used the engine for [Stubbs the Zombie in Rebel Without a Pulse][stubbs]. In fact, it is possible to extract [tags][] from Stubbs using [Refinery][mek] and recompile levels for Halo.
 
 Another lesser-known use was in [prototyping Shadowrun gameplay][shadowrun-prototype] while its own engine was under development.
 

--- a/src/content/h1/games.dot
+++ b/src/content/h1/games.dot
@@ -2,6 +2,7 @@ digraph G {
   # xbox
   node [style=filled color="#8fcc86"]
   xbox_pre [label="Unknown pre-release build"]
+  xbox_1749 [label="Xbox beta 1749\nBuild: 01.08.15.1749"]
   xbox_ntsc_beta [label="Xbox NTSC beta\nBuild: 01.09.25.2247\nEngine version: 5"]
   xbox_ntsc_retail [label="Xbox NTSC retail release\nBuild: 01.10.12.2276\nEngine version: 5"]
   xbox_pal_retail [label="Xbox PAL retail release\nBuild: 01.01.14.2342\nEngine version: 5"]
@@ -40,6 +41,7 @@ digraph G {
   node [style=filled color="#cc86c9"];
   ann [label="Anniversary (Xbox 360)\nBuild: 01.00.01.0563"];
   mcc_xbone [label="MCC (Xbox One)"];
+  mcc_xbone_china [label="MCC (Xbox One)\nCensored Chinese version"];
   mcc_pc [label="MCC (PC)"];
   mcc_pc_live [label="", fixedsize="false", width=0, height=0, shape=none];
   mcc_xbone_live [label="", fixedsize="false", width=0, height=0, shape=none];
@@ -52,7 +54,8 @@ digraph G {
   halomd [label="HaloMD (mod)"];
 
   # xbox line
-  xbox_pre -> xbox_ntsc_beta;
+  xbox_pre -> xbox_1749;
+  xbox_1749 -> xbox_ntsc_beta;
   xbox_ntsc_beta -> xbox_ntsc_retail;
   xbox_ntsc_retail -> xbox_pal_retail;
 
@@ -107,5 +110,6 @@ digraph G {
   pc_gold -> mcc_xbone [label="Multiplayer"];
   mcc_xbone -> mcc_pc;
   mcc_xbone -> mcc_xbone_live [label="Active updates"];
+  mcc_xbone -> mcc_xbone_china;
   mcc_pc -> mcc_pc_live [label="Active updates"];
 }

--- a/src/content/h1/tags/readme.md
+++ b/src/content/h1/tags/readme.md
@@ -9,9 +9,9 @@ thanks:
     for: Information about invalid tags
 ---
 
-Tags are the fundamental unit of resources which comprise a [map][]. They come in many different types (sometimes called tag _classes_ or _groups_), each with a predefined structure and data fields. Tags can reference other tags by their _tag path_, forming a tree-like structure of all resources necessary to compile a map.
+**Tags** are the fundamental unit of resources which comprise a [map][]. They come in many different types (sometimes called tag _classes_ or _groups_), each with a predefined structure and data fields. Tags can [reference](#tag-references-and-paths) other tags, forming a tree-like structure of all resources necessary to compile a map.
 
-The name "tag" was inspired by [XML tags][about-xml], which also have types and a structure with fields. However, unlike XML, Halo's tags are a binary format and not plain text. To create and edit tags, you need to use purpose-built tools like [the HEK][hek], [MEK][], or [Invader][].
+The name "tag" was inspired by [XML tags][about-xml], which also have types and a structure with fields. However, unlike XML, Halo's tags are a binary format rather than plain text. To create and edit tags, you need to use purpose-built tools like [the HEK][hek], [MEK][], or [Invader][].
 
 # Tag structure
 ## Tag references and paths


### PR DESCRIPTION
Based on recent discussions in the reclaimers discord, making a few changes. Here's the diagram rendered out:

![tmp-pr-diagram](https://user-images.githubusercontent.com/1519264/87083318-46ed9880-c1e1-11ea-98b9-06022c5ab186.png)
