### PR TITLE
Add 2020 survey

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -173,6 +173,11 @@
         "buffer-equal": "^1.0.0"
       }
     },
+    "append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY="
+    },
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
@@ -523,8 +528,39 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "busboy": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
+      "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
+      "requires": {
+        "dicer": "0.2.5",
+        "readable-stream": "1.1.x"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
     },
     "bytes": {
       "version": "3.1.0",
@@ -732,7 +768,6 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -791,8 +826,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "d": {
       "version": "1.0.1",
@@ -934,6 +968,38 @@
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
+    },
+    "dicer": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
+      "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
+      "requires": {
+        "readable-stream": "1.1.x",
+        "streamsearch": "0.1.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -2746,8 +2812,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -3111,8 +3176,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minisearch": {
       "version": "2.3.1",
@@ -3140,10 +3204,40 @@
         }
       }
     },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "multer": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.2.tgz",
+      "integrity": "sha512-xY8pX7V+ybyUpbYMxtjM9KAiD9ixtg5/JkeKUTD6xilfDv0vzzOFcCp4Ljb1UU3tSOM3VTZtKo63OmzOrGi3Cg==",
+      "requires": {
+        "append-field": "^1.0.0",
+        "busboy": "^0.2.11",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.1.1",
+        "on-finished": "^2.3.0",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        }
+      }
     },
     "multipipe": {
       "version": "0.1.2",
@@ -3525,8 +3619,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "proxy-addr": {
       "version": "2.0.6",
@@ -3604,7 +3697,6 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -4124,6 +4216,11 @@
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
     },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -4139,7 +4236,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -4297,8 +4393,7 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "unc-path-regex": {
       "version": "0.1.2",
@@ -4417,8 +4512,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -4549,8 +4643,7 @@
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "3.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -859,6 +859,22 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        }
+      }
+    },
     "d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -363,6 +363,22 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "aws-sdk": {
+      "version": "2.720.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.720.0.tgz",
+      "integrity": "sha512-899YXs6iWae82GGJM95S5MFBPIG8pE9aq+GlSr47mz7te97hGX0OcjPs3GuGZWA6Nrp0MCR9eMqu6DwBlYGltA==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      }
+    },
     "bach": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
@@ -441,6 +457,11 @@
         }
       }
     },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
     "beeper": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
@@ -517,6 +538,16 @@
             "is-extendable": "^0.1.0"
           }
         }
+      }
+    },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "buffer-equal": {
@@ -1168,6 +1199,11 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "expand-brackets": {
       "version": "2.1.4",
@@ -2556,6 +2592,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
     "ignore": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
@@ -2825,6 +2866,11 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -3651,10 +3697,20 @@
         "pump": "^2.0.0"
       }
     },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
     "qs": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "range-parser": {
       "version": "1.2.1",
@@ -3893,6 +3949,11 @@
       "requires": {
         "chokidar": ">=2.0.0 <4.0.0"
       }
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "semver": {
       "version": "5.7.1",
@@ -4503,6 +4564,15 @@
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -4518,6 +4588,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "v8flags": {
       "version": "3.1.3",
@@ -4639,6 +4714,20 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://c20.reclaimers.net",
   "dependencies": {
+    "aws-sdk": "^2.720.0",
     "express": "^4.17.1",
     "htm": "^3.0.4",
     "minisearch": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "express": "^4.17.1",
     "htm": "^3.0.4",
     "minisearch": "^2.3.1",
+    "multer": "^1.4.2",
     "serve-static": "^1.14.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://c20.reclaimers.net",
   "dependencies": {
     "aws-sdk": "^2.720.0",
+    "cors": "^2.8.5",
     "express": "^4.17.1",
     "htm": "^3.0.4",
     "minisearch": "^2.3.1",

--- a/server.js
+++ b/server.js
@@ -1,10 +1,17 @@
 const express = require("express");
 const serveStatic = require("serve-static");
+const multer = require("multer");
 
 module.exports = function() {
   const port = process.env.C20_PORT ? Number(process.env.C20_PORT) : 8080;
   const app = express();
   app.use("/", serveStatic("./dist"));
+
+  app.post("/survey/submit", multer().none(), (req, res) => {
+    console.log(req.body);
+    res.redirect("/");
+  });
+
   app.listen(port);
   console.log(`Serving at http://localhost:${port}/`);
 };

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const serveStatic = require("serve-static");
 const multer = require("multer");
 const crypto = require("crypto");
 const AWS = require("aws-sdk");
+const cors = require("cors");
 
 module.exports = function() {
   const port = process.env.C20_PORT ? Number(process.env.C20_PORT) : 8080;
@@ -32,7 +33,7 @@ module.exports = function() {
   const app = express();
   app.use("/", serveStatic("./dist"));
 
-  app.post("/survey/submit", multer().none(), (req, res) => {
+  app.post("/survey/submit", cors(), multer().none(), (req, res) => {
     const ip = req.headers["x-forwarded-for"] || req.connection.remoteAddress;
     const ipHash = crypto.createHash("md5").update(ip).digest("hex");
     const date = new Date().toISOString();

--- a/server.js
+++ b/server.js
@@ -1,15 +1,51 @@
 const express = require("express");
 const serveStatic = require("serve-static");
 const multer = require("multer");
+const crypto = require("crypto");
+const AWS = require("aws-sdk");
 
 module.exports = function() {
   const port = process.env.C20_PORT ? Number(process.env.C20_PORT) : 8080;
+  const bucketName = process.env.C20_S3_BUCKET || "reclaimers-data-test";
+  const s3 = new AWS.S3();
+
+  const saveSurvey = function(surveyData, cb) {
+    const s3Params = {Bucket: bucketName, Key: "survey-results.json"};
+    s3.getObject(s3Params, (err, data) => {
+      if (err && err.statusCode != 404) {
+        return cb(err);
+      }
+      const results = err ? {} : JSON.parse(data.Body.toString());
+      results[surveyData.ipHash] = surveyData;
+      const putParams = {
+        ...s3Params,
+        Body: JSON.stringify(results),
+        "ContentType": "application/json",
+        "ACL": "public-read"
+      };
+      s3.putObject(putParams, (err) => {
+        cb(err);
+      });
+    });
+  };
+
   const app = express();
   app.use("/", serveStatic("./dist"));
 
   app.post("/survey/submit", multer().none(), (req, res) => {
-    console.log(req.body);
-    res.redirect("/");
+    const ip = req.headers["x-forwarded-for"] || req.connection.remoteAddress;
+    const ipHash = crypto.createHash("md5").update(ip).digest("hex");
+    const date = new Date().toISOString();
+    const surveyData = {...req.body, ipHash, date};
+    saveSurvey(surveyData, (err) => {
+      if (err) {
+        console.error(`Failed to save survey data for ${ipHash}`, err);
+        res.status(500).send("Internal server error");
+        return;
+      }
+      console.log(`Saved survey data for ${ipHash}`);
+      res.redirect("/");
+    });
   });
 
   app.listen(port);

--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -101,8 +101,22 @@ button {
   }
 }
 
-label {
+label, legend {
   font-weight: bold;
+}
+
+fieldset {
+  border: 1px solid $border-color;
+  // background: $bg-inset;
+  margin-bottom: $padding-flow;
+
+  label {
+    font-weight: normal;
+  }
+}
+
+label {
+  cursor: pointer;
 }
 
 input {
@@ -125,6 +139,18 @@ input {
     &:hover {
       background: $bg-overlay;
     }
+  }
+}
+
+input[type="radio"], input[type="checkbox"] {
+  display: inline-block;
+}
+
+.radio-options {
+  display: flex;
+  flex-direction: row;
+  .radio-option {
+    margin-right: 1em;
   }
 }
 

--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -142,8 +142,49 @@ input {
   }
 }
 
-input[type="radio"], input[type="checkbox"] {
+input[type="radio"] {
   display: inline-block;
+  margin: 0;
+  padding: 0;
+  opacity: 0;
+  & + label:before {
+    content: '';
+    display: inline-block;
+    position: absolute;
+    margin-left: -26px;
+    padding: 8px;
+    border: 2px solid $border-color;
+    border-radius: 2em;
+  }
+  &:checked + label:before {
+    border: 2px solid $fg-strong;
+    background: $fg-link;
+  }
+  &:checked + label {
+    color: $fg-strong;
+  }
+}
+
+input[type="checkbox"] {
+  display: inline-block;
+  margin: 0;
+  padding: 0;
+  opacity: 0;
+  & + label:before {
+    content: '';
+    display: inline-block;
+    position: absolute;
+    margin-left: -26px;
+    padding: 8px;
+    border: 2px solid $border-color;
+  }
+  &:checked + label:before {
+    border: 2px solid $fg-strong;
+    background: $fg-link;
+  }
+  &:checked + label {
+    color: $fg-strong;
+  }
 }
 
 .radio-options {

--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -101,7 +101,12 @@ button {
   }
 }
 
+label {
+  font-weight: bold;
+}
+
 input {
+  display: block;
   border-radius: $border-radius;
   border: 1px solid $border-color;
   background: $bg-inset;
@@ -344,6 +349,7 @@ table.tag-struct {
   }
 
   .search-input {
+    display: inline-block;
     transition: width $transition-time;
     width: 60%;
     &:focus, &.nonempty {

--- a/src/content/survey/readme.md
+++ b/src/content/survey/readme.md
@@ -1,0 +1,31 @@
+---
+title: Modding community survey (2020)
+---
+We would love to hear from members of the modding community to help prioritize work on c20. Please take a few minutes to fill out this survey 💕.
+
+<form method="post" action="/survey/submit" enctype="multipart/form-data">
+
+# About you
+<label>
+How many years have you been involved in the community?
+<input name="years" min="0" type="number" required/>
+</label>
+
+...
+
+# Art and asset creation
+...
+
+# Mapping
+...
+
+# Programming and client mods
+...
+
+---
+
+Thanks for taking the time to fill out this survey!
+
+<button type="submit">Submit</button>
+
+</form>

--- a/src/content/survey/readme.md
+++ b/src/content/survey/readme.md
@@ -4,6 +4,6 @@ isSurvey: true
 ---
 _The Reclaimers Library_ is a project which aims to capture the Halo CE modding community's knowledge in one place. Think of it like an extended HEK tutorial, but not restricted to the HEK. There's a lot of ground to cover, which is why we need your help prioritizing content.
 
-For example, have you always wanted to make custom vehicles but never knew how? Can't wrap your head around portals, or the mysteries of scripting? Or are you curious about modding MCC H1, H2, or H3?
+For example, have you always wanted to make custom vehicles but never knew how? Can't wrap your head around portals, or the mysteries of scripting? Or are you curious about modding MCC H1, H2, or H3? By completing the below survey, we'll know what to focus on documenting.
 
-By completing the below survey, we'll know what to focus on documenting. Don't forget to hit **Submit** at the bottom of the page!
+Don't forget to hit **Submit** at the bottom of the page! The survey takes about 10 minutes to complete, but does not need to be fully completed in order to submit.

--- a/src/content/survey/readme.md
+++ b/src/content/survey/readme.md
@@ -1,31 +1,9 @@
 ---
-title: Modding community survey (2020)
+title: Community survey 2020
+isSurvey: true
 ---
-We would love to hear from members of the modding community to help prioritize work on c20. Please take a few minutes to fill out this survey 💕.
+_The Reclaimers Library_ is a project which aims to capture the Halo CE modding community's knowledge in one place. Think of it like an extended HEK tutorial, but not restricted to the HEK. There's a lot of ground to cover, which is why we need your help prioritizing content.
 
-<form method="post" action="/survey/submit" enctype="multipart/form-data">
+For example, have you always wanted to make custom vehicles but never knew how? Can't wrap your head around portals, or the mysteries of scripting? Or are you curious about modding MCC H1, H2, or H3?
 
-# About you
-<label>
-How many years have you been involved in the community?
-<input name="years" min="0" type="number" required/>
-</label>
-
-...
-
-# Art and asset creation
-...
-
-# Mapping
-...
-
-# Programming and client mods
-...
-
----
-
-Thanks for taking the time to fill out this survey!
-
-<button type="submit">Submit</button>
-
-</form>
+By completing the below survey, we'll know what to focus on documenting. Don't forget to hit **Submit** at the bottom of the page!

--- a/src/render/components/index.js
+++ b/src/render/components/index.js
@@ -2,6 +2,7 @@ module.exports = {
   wrapper: require("./wrapper/wrapper"),
   metabox: require("./metabox"),
   thanks: require("./thanks"),
+  survey: require("./survey"),
   ...require("./markdown"),
   ...require("./tag"),
   ...require("./workflows"),

--- a/src/render/components/survey.js
+++ b/src/render/components/survey.js
@@ -87,6 +87,8 @@ const body = html`
     {id: "audio", label: "Music or sound effects"},
     {id: "tags", label: "Tag editing"},
     {id: "maps", label: "Custom maps"},
+    {id: "halo-scripting", label: "Halo scripting"},
+    {id: "lua-scripting", label: "Lua scripting"},
   ])}
 
   ${checkAny("games", "What Halo games are you interested in modding?", [
@@ -97,6 +99,7 @@ const body = html`
     {id: "h2v", label: "Halo 2 Vista/Project Cartographer"},
     {id: "h2mcc", label: "Halo 2 MCC"},
     {id: "h3mcc", label: "Halo 3 MCC"},
+    {id: "hrmcc", label: "Halo Reach MCC"},
   ])}
 
   ${section(1, "General software")}
@@ -111,6 +114,7 @@ const body = html`
   ${experience("2d-photoshop", "Using Photoshop")}
   ${experience("2d-gimp", "Using GIMP")}
   ${experience("2d-krita", "Using Krita")}
+  ${experience("2d-paint-net", "Using Paint.NET")}
   ${experience("2d-alpha", "Alpha channels")}
   ${experience("2d-porting", "Porting bitmaps from other Halo games to H1")}
 

--- a/src/render/components/survey.js
+++ b/src/render/components/survey.js
@@ -1,50 +1,44 @@
 const {html, heading, slugify} = require("./bits");
 
-const experience = (title) => {
-  const id = slugify(title);
+const experience = (id, title) => {
   return html`
     <fieldset>
       <legend>${title}</legend>
       <div class="radio-options">
         <div class="radio-option">
-          <input type="radio" id="${id + "-0"}" name="${id}">
-          <label for="${id + "-0"}">Unknown</label>
+          <input type="radio" id="${id + "-0"}" name="${id}" value="unknown">
+          <label for="${id + "-0"}">What's that?</label>
         </div>
         <div class="radio-option">
-          <input type="radio" id="${id + "-1"}" name="${id}">
-          <label for="${id + "-1"}">Uninterested</label>
+          <input type="radio" id="${id + "-1"}" name="${id}" value="uninterested">
+          <label for="${id + "-1"}">Uninterested for now</label>
         </div>
         <div class="radio-option">
-          <input type="radio" id="${id + "-2"}" name="${id}">
-          <label for="${id + "-2"}">Interested</label>
+          <input type="radio" id="${id + "-2"}" name="${id}" value="curious">
+          <label for="${id + "-2"}">Curious about</label>
         </div>
         <div class="radio-option">
-          <input type="radio" id="${id + "-3"}" name="${id}">
-          <label for="${id + "-3"}">Beginner</label>
+          <input type="radio" id="${id + "-3"}" name="${id}" value="need-help">
+          <label for="${id + "-3"}">Tried, need help</label>
         </div>
         <div class="radio-option">
-          <input type="radio" id="${id + "-4"}" name="${id}">
-          <label for="${id + "-4"}">Intermediate</label>
-        </div>
-        <div class="radio-option">
-          <input type="radio" id="${id + "-5"}" name="${id}">
-          <label for="${id + "-5"}">Expert</label>
+          <input type="radio" id="${id + "-4"}" name="${id}" value="easy">
+          <label for="${id + "-4"}">Tried, easy</label>
         </div>
       </div>
     </fieldset>
   `;
 };
 
-const checkAny = (title, opts) => {
-  const id = slugify(title);
+const checkAny = (id, title, opts) => {
   return html`
     <fieldset>
       <legend>${title} <small><em>(Check all that apply)</em></small></legend>
-      ${opts.map(opt => {
-        const optId = id + "-" + slugify(opt);
+      ${opts.map(({label, id: optId}) => {
+        const optIdJoined = id + "-" + optId;
         return html`
-          <input type="checkbox" id="${optId}">
-          <label for="${optId}">${opt}</label>
+          <input type="checkbox" id="${optIdJoined}" name="${optIdJoined}">
+          <label for="${optIdJoined}">${label}</label>
           <br>
         `;
       })}
@@ -63,164 +57,177 @@ const body = html`
   <form method="post" action="/survey/submit" enctype="multipart/form-data">
 
   ${section(1, "Intro")}
-  ${checkAny("What operating system(s) do you use for modding?", [
-    "Windows",
-    "Linux",
-    "Mac"
+
+  <fieldset>
+    <legend for="years">How many years have you been modding Halo?</legend>
+    <select id="years" name="years">
+      <option value="">--</option>
+      <option value="">1 or less</option>
+      <option value="2-3">2-3 years</option>
+      <option value="4-6">4-6 years</option>
+      <option value="7-10">7-10 years</option>
+      <option value="11-plus">11+ years</option>
+    </select>
+  </fieldset>
+
+  ${checkAny("os", "What operating system(s) do you use for modding?", [
+    {id: "windows", label: "Windows"},
+    {id: "linux", label: "Linux"},
+    {id: "mac", label: "Mac"},
   ])}
 
-  ${checkAny("What types of activities do you partake in?", [
-    "Modeling",
-    "Texturing",
-    "Animating",
-    "Documentation or educational content (e.g. tutorials, YouTube videos)",
-    "Community building (e.g. running or moderating community groups, organizing events)",
-    "Streaming and gameplay videos, montages",
-    "Server hosting",
-    "Music or sound effects",
-    "Tag editing",
-    "Custom maps",
+  ${checkAny("activities", "What types of activities do you partake in?", [
+    {id: "modeling", label: "Modeling"},
+    {id: "texturing", label: "Texturing"},
+    {id: "animating", label: "Animating"},
+    {id: "documentation", label: "Documentation or educational content (e.g. tutorials, YouTube videos)"},
+    {id: "community", label: "Community building (e.g. running or moderating community groups, organizing events)"},
+    {id: "gameplay", label: "Streaming and gameplay videos, montages"},
+    {id: "hosting", label: "Server hosting"},
+    {id: "audio", label: "Music or sound effects"},
+    {id: "tags", label: "Tag editing"},
+    {id: "maps", label: "Custom maps"},
   ])}
 
-  ${checkAny("What Halo games are you interested in modding?", [
-    "Halo 1 Xbox",
-    "Halo 1 PC (Retail)",
-    "Halo 1 Custom Edition",
-    "Halo 1 MCC",
-    "Halo 2 Vista/Project Cartographer",
-    "Halo 2 MCC",
-    "Halo 3 MCC",
+  ${checkAny("games", "What Halo games are you interested in modding?", [
+    {id: "h1x", label: "Halo 1 Xbox"},
+    {id: "h1pc", label: "Halo 1 PC (Retail)"},
+    {id: "h1ce", label: "Halo 1 Custom Edition"},
+    {id: "h1mcc", label: "Halo 1 MCC"},
+    {id: "h2v", label: "Halo 2 Vista/Project Cartographer"},
+    {id: "h2mcc", label: "Halo 2 MCC"},
+    {id: "h3mcc", label: "Halo 3 MCC"},
   ])}
 
   ${section(1, "General software")}
   ${section(2, "3D asset creation")}
-  ${experience("Using Blender")}
-  ${experience("Using 3ds Max")}
-  ${experience("Using Maya")}
-  ${experience("UV unwrapping (any software)")}
-  ${experience("Porting models from other Halo games to H1")}
+  ${experience("3d-blender", "Using Blender")}
+  ${experience("3d-3dsmax", "Using 3ds Max")}
+  ${experience("3d-maya", "Using Maya")}
+  ${experience("3d-uv-unwrapping", "UV unwrapping (any software)")}
+  ${experience("3d-porting", "Porting models from other Halo games to H1")}
 
   ${section(2, "2D asset creation")}
-  ${experience("Using Photoshop")}
-  ${experience("Using GIMP")}
-  ${experience("Using Krita")}
-  ${experience("Bits per channel")}
-  ${experience("Alpha channels")}
-  ${experience("Porting bitmaps from other Halo games to H1")}
+  ${experience("2d-photoshop", "Using Photoshop")}
+  ${experience("2d-gimp", "Using GIMP")}
+  ${experience("2d-krita", "Using Krita")}
+  ${experience("2d-alpha", "Alpha channels")}
+  ${experience("2d-porting", "Porting bitmaps from other Halo games to H1")}
 
   ${section(2, "Other software")}
-  ${experience("Version control (e.g. git, subversion)")}
-  ${experience("Audio editing/DAWs (e.g. Audacity, Reaper)")}
+  ${experience("soft-vcs", "Version control (e.g. git, subversion)")}
+  ${experience("soft-audio", "Audio editing/DAWs (e.g. Audacity, Reaper)")}
 
   ${section(1, "Halo toolkits and mods")}
-  ${experience("HEK - Halo Editing Kit")}
-  ${experience("OpenSauce")}
-  ${experience("MEK - Mozz Editing Kit")}
-  ${experience("Invader")}
-  ${experience("HAC2, Optic")}
-  ${experience("Chimera, lua scripting")}
+  ${experience("tools-hek", "HEK - Halo Editing Kit")}
+  ${experience("tools-opensauce", "OpenSauce")}
+  ${experience("tools-mek", "MEK - Mozz Editing Kit")}
+  ${experience("tools-invader", "Invader")}
+  ${experience("tools-hac2", "HAC2, Optic")}
+  ${experience("tools-chimera", "Chimera, lua scripting")}
 
   ${section(1, "Tags")}
   ${section(2, "General tags")}
-  ${experience("Editing tags with Guerilla/OS_Guerilla")}
-  ${experience("Editing tags with invader-edit-qt")}
-  ${experience("Editing tags with Mozzarilla")}
-  ${experience("Real-time tag editing")}
-  ${experience("Extracting tags")}
-  ${experience("Sharing and releasing tags")}
-  ${experience("Finding publicly-shared tags")}
-  ${experience("Organizing the tags directory")}
+  ${experience("tags-guerilla", "Editing tags with Guerilla/OS_Guerilla")}
+  ${experience("tags-invader", "Editing tags with invader-edit-qt")}
+  ${experience("tags-mozz", "Editing tags with Mozzarilla")}
+  ${experience("tags-realtime", "Real-time tag editing")}
+  ${experience("tags-extracting", "Extracting tags")}
+  ${experience("tags-sharing", "Sharing and releasing tags")}
+  ${experience("tags-finding", "Finding publicly-shared tags")}
+  ${experience("tags-organizing", "Organizing the tags directory")}
 
   ${section(2, "Shaders and bitmaps")}
-  ${experience("Compiling bitmaps")}
-  ${experience("Bitmap compression")}
-  ${experience("Cubemaps")}
-  ${experience("Multipurpose bitmaps")}
-  ${experience("Detail maps")}
-  ${experience("Texture animation")}
-  ${experience("Colour change (e.g. armour)")}
-  ${experience("Shader lens flares")}
-  ${experience("Model shaders")}
-  ${experience("Environment shaders")}
-  ${experience("Chicago/extended shaders")}
-  ${experience("Plasma shaders")}
-  ${experience("Glass shaders")}
-  ${experience("Water shaders")}
-  ${experience("Meter shaders")}
+  ${experience("bitm-compiling", "Compiling bitmaps")}
+  ${experience("bitm-compression", "Bitmap compression")}
+  ${experience("bitm-cubemaps", "Cubemaps")}
+  ${experience("bitm-multipurpose", "Multipurpose bitmaps")}
+  ${experience("bitm-detail", "Detail maps")}
+  ${experience("shdr-anim", "Texture animation")}
+  ${experience("shdr-colour", "Colour change (e.g. armour)")}
+  ${experience("shdr-lensflare", "Shader lens flares")}
+  ${experience("shdr-model", "Model shaders")}
+  ${experience("shdr-env", "Environment shaders")}
+  ${experience("shdr-chicago", "Chicago/extended shaders")}
+  ${experience("shdr-plasma", "Plasma shaders")}
+  ${experience("shdr-glass", "Glass shaders")}
+  ${experience("shdr-water", "Water shaders")}
+  ${experience("shdr-meter", "Meter shaders")}
 
   ${section(2, "Other tags and concepts")}
-  ${experience("Custom HUD elements")}
-  ${experience("Custom fonts")}
-  ${experience("Strings (e.g. cinematic titles, pickup messages)")}
-  ${experience("Functions (e.g. \"A in\", \"C out\")")}
-  ${experience("Projectiles and contrails")}
-  ${experience("Effects")}
-  ${experience("Particles and point physics")}
-  ${experience("Glow and lightning tags")}
+  ${experience("tags-hud", "Custom HUD elements")}
+  ${experience("tags-fonts", "Custom fonts")}
+  ${experience("tags-strings", "Strings (e.g. cinematic titles, pickup messages)")}
+  ${experience("tags-funcs", "Functions (e.g. \"A in\", \"C out\")")}
+  ${experience("tags-proj-contr", "Projectiles and contrails")}
+  ${experience("tags-effects", "Effects")}
+  ${experience("tags-particles-pphys", "Particles and point physics")}
+  ${experience("tags-glow-lightn", "Glow and lightning tags")}
 
   ${section(2, "Objects and items")}
-  ${experience("Device machines, light fixures, and controls")}
-  ${experience("Custom scenery")}
-  ${experience("Model regions")}
-  ${experience("Extracting models for modification")}
-  ${experience("Collision models")}
-  ${experience("Widget attachments (e.g. lights, antennas")}
-  ${experience("Markers and nodes")}
-  ${experience("Animation types (overlay, replacement, etc)")}
-  ${experience("Vehicle physics")}
-  ${experience("Vehicles and seats")}
-  ${experience("Rider animations")}
-  ${experience("Custom bipeds")}
-  ${experience("3rd person animations")}
-  ${experience("Custom weapons")}
-  ${experience("First person animations")}
-  ${experience("Custom equipment")}
+  ${experience("obj-device", "Device machines, light fixures, and controls")}
+  ${experience("obj-scenery", "Custom scenery")}
+  ${experience("obj-regions", "Model regions")}
+  ${experience("obj-extraction", "Extracting models for modification")}
+  ${experience("obj-collision", "Collision models")}
+  ${experience("obj-widgets", "Widget attachments (e.g. lights, antennas")}
+  ${experience("obj-markers-nodes", "Markers and nodes")}
+  ${experience("obj-anim-types", "Animation types (overlay, replacement, etc)")}
+  ${experience("obj-physics", "Vehicle physics")}
+  ${experience("obj-vehicles", "Vehicles and seats")}
+  ${experience("obj-riders", "Rider animations")}
+  ${experience("obj-bipeds", "Custom bipeds")}
+  ${experience("obj-3p-anim", "3rd person animations")}
+  ${experience("obj-weapons", "Custom weapons")}
+  ${experience("obj-1p-anim", "First person animations")}
+  ${experience("obj-equipment", "Custom equipment")}
 
   ${section(1, "Map-making")}
   ${section(2, "General map-making")}
-  ${experience("BSP modeling")}
-  ${experience("Material flags")}
-  ${experience("Lighting and lightmaps")}
-  ${experience("Portals")}
-  ${experience("Fog planes")}
-  ${experience("Weather polyhedra/volumes")}
-  ${experience("Sapien")}
-  ${experience("Sound environments")}
-  ${experience("Weather and wind")}
-  ${experience("Scenery and sound scenery placement")}
-  ${experience("Detail objects and decals")}
-  ${experience("Custom UI maps")}
-  ${experience("Custom resource maps")}
-  ${experience("Custom skyboxes")}
-  ${experience("Extracting BSPs for modification")}
+  ${experience("map-modeling", "BSP modeling")}
+  ${experience("map-materials", "Materials and material flags")}
+  ${experience("map-lighting", "Lighting and lightmaps")}
+  ${experience("map-portals", "Portals")}
+  ${experience("map-fog", "Fog planes")}
+  ${experience("map-weather-vol", "Weather polyhedra/volumes")}
+  ${experience("map-sapien", "Using Sapien")}
+  ${experience("map-sound-env", "Sound environments")}
+  ${experience("map-weather-wind", "Weather and wind")}
+  ${experience("map-scenery", "Scenery and sound scenery placement")}
+  ${experience("map-detail-decals", "Detail objects and decals")}
+  ${experience("map-ui", "Custom UI maps")}
+  ${experience("map-resource", "Custom resource maps")}
+  ${experience("map-skyboxes", "Custom skyboxes")}
+  ${experience("map-bsp-extraction", "Extracting BSPs for modification")}
 
   ${section(2, "Multiplayer maps")}
-  ${experience("Netgame flags and multiplayer setup")}
-  ${experience("Multiplayer balancing strategies")}
-  ${experience("Netcode sync workarounds (e.g. biped crushers)")}
+  ${experience("mp-netgame", "Netgame flags and multiplayer setup")}
+  ${experience("mp-balancing", "Multiplayer balancing strategies")}
+  ${experience("mp-sync-hacks", "Netcode sync workarounds (e.g. biped crushers)")}
 
   ${section(2, "Singleplayer maps")}
-  ${experience("Scripting")}
-  ${experience("Cinematics")}
-  ${experience("Dialogue")}
-  ${experience("Recorded animations")}
-  ${experience("Device control groups")}
-  ${experience("AI and encounter setup")}
-  ${experience("AI behaviour and balancing strategies")}
+  ${experience("sp-scripting", "Scripting")}
+  ${experience("sp-cinematics", "Cinematics")}
+  ${experience("sp-dialogue", "Dialogue")}
+  ${experience("sp-recorded-anim", "Recorded animations")}
+  ${experience("sp-device-groups", "Device control groups")}
+  ${experience("sp-encounters", "AI and encounter setup")}
+  ${experience("sp-balancing", "AI behaviour and balancing strategies")}
 
   ${section(1, "Servers")}
-  ${experience("Hosting dedicated servers")}
-  ${experience("Server mods (e.g. SAPP)")}
-  ${experience("Console commands and rcon")}
+  ${experience("servers-hosting", "Hosting dedicated servers")}
+  ${experience("servers-mods", "Server mods (e.g. SAPP)")}
+  ${experience("servers-commands", "Console commands and rcon")}
 
   ${section(1, "Programming and reverse engineering")}
-  ${experience("Hooking/patching game code")}
-  ${experience("Programmatically editing or creating tags with Reclaimer")}
-  ${experience("Using Cheat Engine")}
+  ${experience("prog-hook", "Hooking/patching game code")}
+  ${experience("prog-tags", "Programmatically editing or creating tags with Reclaimer")}
+  ${experience("prog-cheat-engine", "Using Cheat Engine")}
+  ${experience("prog-engine", "How Halo's engine works (e.g. tag tables, game state)")}
 
   <hr>
   <p>Thanks for taking the time to fill out this survey! 💕 Results will be posted in Discord once the survey is complete.</p>
-  <button type="submit">Submit</button>
+  <button type="submit">Submit and return to home</button>
   </form>
   <br>
 `;

--- a/src/render/components/survey.js
+++ b/src/render/components/survey.js
@@ -19,11 +19,11 @@ const experience = (id, title) => {
         </div>
         <div class="radio-option">
           <input type="radio" id="${id + "-3"}" name="${id}" value="need-help">
-          <label for="${id + "-3"}">Tried, need help</label>
+          <label for="${id + "-3"}">I would like more info</label>
         </div>
         <div class="radio-option">
           <input type="radio" id="${id + "-4"}" name="${id}" value="easy">
-          <label for="${id + "-4"}">Tried, easy</label>
+          <label for="${id + "-4"}">I know how to do this</label>
         </div>
       </div>
     </fieldset>
@@ -54,7 +54,7 @@ const section = (level, title) => {
 };
 
 const body = html`
-  <form method="post" action="/survey/submit" enctype="multipart/form-data">
+  <form method="post" action="http://api.reclaimers.net:8080/survey/submit" enctype="multipart/form-data">
 
   ${section(1, "Intro")}
 

--- a/src/render/components/survey.js
+++ b/src/render/components/survey.js
@@ -1,0 +1,228 @@
+const {html, heading, slugify} = require("./bits");
+
+const experience = (title) => {
+  const id = slugify(title);
+  return html`
+    <fieldset>
+      <legend>${title}</legend>
+      <div class="radio-options">
+        <div class="radio-option">
+          <input type="radio" id="${id + "-0"}" name="${id}">
+          <label for="${id + "-0"}">Unknown</label>
+        </div>
+        <div class="radio-option">
+          <input type="radio" id="${id + "-1"}" name="${id}">
+          <label for="${id + "-1"}">Uninterested</label>
+        </div>
+        <div class="radio-option">
+          <input type="radio" id="${id + "-2"}" name="${id}">
+          <label for="${id + "-2"}">Interested</label>
+        </div>
+        <div class="radio-option">
+          <input type="radio" id="${id + "-3"}" name="${id}">
+          <label for="${id + "-3"}">Beginner</label>
+        </div>
+        <div class="radio-option">
+          <input type="radio" id="${id + "-4"}" name="${id}">
+          <label for="${id + "-4"}">Intermediate</label>
+        </div>
+        <div class="radio-option">
+          <input type="radio" id="${id + "-5"}" name="${id}">
+          <label for="${id + "-5"}">Expert</label>
+        </div>
+      </div>
+    </fieldset>
+  `;
+};
+
+const checkAny = (title, opts) => {
+  const id = slugify(title);
+  return html`
+    <fieldset>
+      <legend>${title} <small><em>(Check all that apply)</em></small></legend>
+      ${opts.map(opt => {
+        const optId = id + "-" + slugify(opt);
+        return html`
+          <input type="checkbox" id="${optId}">
+          <label for="${optId}">${opt}</label>
+          <br>
+        `;
+      })}
+    </fieldset>
+  `;
+};
+
+const headings = [];
+
+const section = (level, title) => {
+  headings.push({title, id: slugify(title), level});
+  return heading("h" + level, title);
+};
+
+const body = html`
+  <form method="post" action="/survey/submit" enctype="multipart/form-data">
+
+  ${section(1, "Intro")}
+  ${checkAny("What operating system(s) do you use for modding?", [
+    "Windows",
+    "Linux",
+    "Mac"
+  ])}
+
+  ${checkAny("What types of activities do you partake in?", [
+    "Modeling",
+    "Texturing",
+    "Animating",
+    "Documentation or educational content (e.g. tutorials, YouTube videos)",
+    "Community building (e.g. running or moderating community groups, organizing events)",
+    "Streaming and gameplay videos, montages",
+    "Server hosting",
+    "Music or sound effects",
+    "Tag editing",
+    "Custom maps",
+  ])}
+
+  ${checkAny("What Halo games are you interested in modding?", [
+    "Halo 1 Xbox",
+    "Halo 1 PC (Retail)",
+    "Halo 1 Custom Edition",
+    "Halo 1 MCC",
+    "Halo 2 Vista/Project Cartographer",
+    "Halo 2 MCC",
+    "Halo 3 MCC",
+  ])}
+
+  ${section(1, "General software")}
+  ${section(2, "3D asset creation")}
+  ${experience("Using Blender")}
+  ${experience("Using 3ds Max")}
+  ${experience("Using Maya")}
+  ${experience("UV unwrapping (any software)")}
+  ${experience("Porting models from other Halo games to H1")}
+
+  ${section(2, "2D asset creation")}
+  ${experience("Using Photoshop")}
+  ${experience("Using GIMP")}
+  ${experience("Using Krita")}
+  ${experience("Bits per channel")}
+  ${experience("Alpha channels")}
+  ${experience("Porting bitmaps from other Halo games to H1")}
+
+  ${section(2, "Other software")}
+  ${experience("Version control (e.g. git, subversion)")}
+  ${experience("Audio editing/DAWs (e.g. Audacity, Reaper)")}
+
+  ${section(1, "Halo toolkits and mods")}
+  ${experience("HEK - Halo Editing Kit")}
+  ${experience("OpenSauce")}
+  ${experience("MEK - Mozz Editing Kit")}
+  ${experience("Invader")}
+  ${experience("HAC2, Optic")}
+  ${experience("Chimera, lua scripting")}
+
+  ${section(1, "Tags")}
+  ${section(2, "General tags")}
+  ${experience("Editing tags with Guerilla/OS_Guerilla")}
+  ${experience("Editing tags with invader-edit-qt")}
+  ${experience("Editing tags with Mozzarilla")}
+  ${experience("Real-time tag editing")}
+  ${experience("Extracting tags")}
+  ${experience("Sharing and releasing tags")}
+  ${experience("Finding publicly-shared tags")}
+  ${experience("Organizing the tags directory")}
+
+  ${section(2, "Shaders and bitmaps")}
+  ${experience("Compiling bitmaps")}
+  ${experience("Bitmap compression")}
+  ${experience("Cubemaps")}
+  ${experience("Multipurpose bitmaps")}
+  ${experience("Detail maps")}
+  ${experience("Texture animation")}
+  ${experience("Colour change (e.g. armour)")}
+  ${experience("Shader lens flares")}
+  ${experience("Model shaders")}
+  ${experience("Environment shaders")}
+  ${experience("Chicago/extended shaders")}
+  ${experience("Plasma shaders")}
+  ${experience("Glass shaders")}
+  ${experience("Water shaders")}
+  ${experience("Meter shaders")}
+
+  ${section(2, "Other tags and concepts")}
+  ${experience("Custom HUD elements")}
+  ${experience("Custom fonts")}
+  ${experience("Strings (e.g. cinematic titles, pickup messages)")}
+  ${experience("Functions (e.g. \"A in\", \"C out\")")}
+  ${experience("Projectiles and contrails")}
+  ${experience("Effects")}
+  ${experience("Particles and point physics")}
+  ${experience("Glow and lightning tags")}
+
+  ${section(2, "Objects and items")}
+  ${experience("Device machines, light fixures, and controls")}
+  ${experience("Custom scenery")}
+  ${experience("Model regions")}
+  ${experience("Extracting models for modification")}
+  ${experience("Collision models")}
+  ${experience("Widget attachments (e.g. lights, antennas")}
+  ${experience("Markers and nodes")}
+  ${experience("Animation types (overlay, replacement, etc)")}
+  ${experience("Vehicle physics")}
+  ${experience("Vehicles and seats")}
+  ${experience("Rider animations")}
+  ${experience("Custom bipeds")}
+  ${experience("3rd person animations")}
+  ${experience("Custom weapons")}
+  ${experience("First person animations")}
+  ${experience("Custom equipment")}
+
+  ${section(1, "Map-making")}
+  ${section(2, "General map-making")}
+  ${experience("BSP modeling")}
+  ${experience("Material flags")}
+  ${experience("Lighting and lightmaps")}
+  ${experience("Portals")}
+  ${experience("Fog planes")}
+  ${experience("Weather polyhedra/volumes")}
+  ${experience("Sapien")}
+  ${experience("Sound environments")}
+  ${experience("Weather and wind")}
+  ${experience("Scenery and sound scenery placement")}
+  ${experience("Detail objects and decals")}
+  ${experience("Custom UI maps")}
+  ${experience("Custom resource maps")}
+  ${experience("Custom skyboxes")}
+  ${experience("Extracting BSPs for modification")}
+
+  ${section(2, "Multiplayer maps")}
+  ${experience("Netgame flags and multiplayer setup")}
+  ${experience("Multiplayer balancing strategies")}
+  ${experience("Netcode sync workarounds (e.g. biped crushers)")}
+
+  ${section(2, "Singleplayer maps")}
+  ${experience("Scripting")}
+  ${experience("Cinematics")}
+  ${experience("Dialogue")}
+  ${experience("Recorded animations")}
+  ${experience("Device control groups")}
+  ${experience("AI and encounter setup")}
+  ${experience("AI behaviour and balancing strategies")}
+
+  ${section(1, "Servers")}
+  ${experience("Hosting dedicated servers")}
+  ${experience("Server mods (e.g. SAPP)")}
+  ${experience("Console commands and rcon")}
+
+  ${section(1, "Programming and reverse engineering")}
+  ${experience("Hooking/patching game code")}
+  ${experience("Programmatically editing or creating tags with Reclaimer")}
+  ${experience("Using Cheat Engine")}
+
+  <hr>
+  <p>Thanks for taking the time to fill out this survey! 💕 Results will be posted in Discord once the survey is complete.</p>
+  <button type="submit">Submit</button>
+  </form>
+  <br>
+`;
+
+module.exports = {headings, body};

--- a/src/render/render.js
+++ b/src/render/render.js
@@ -1,7 +1,8 @@
 const {
   detailsList, anchor, metabox, ul, wrapper, renderMarkdown, defAnchor,
   html, alert, thanks: renderThanks, REPO_URL, heading, tagAnchor,
-  workflowItemAnchor, workflowsList, tagsTable, renderTagStructure
+  workflowItemAnchor, workflowsList, tagsTable, renderTagStructure,
+  survey
 } = require("./components");
 
 const STUB_ALERT = {type: "danger", body: html`
@@ -206,6 +207,14 @@ module.exports = (page, metaIndex) => {
       ${ul(allThanks)}
     `);
     wrapperProps._headers.push({title: "Thank you!", id: "thank-you", level: 2});
+  }
+
+  if (page.isSurvey) {
+    articleBodySections.push(survey.body);
+    wrapperProps._headers = [
+      ...wrapperProps._headers,
+      ...survey.headings
+    ];
   }
 
   const htmlDoc = wrapper(wrapperProps, metaIndex, html`


### PR DESCRIPTION
To prioritize content for the wiki, we need to know what our users want. This PR adds a `/survey` page with a form designed to answer that question. Form submissions are posted to an API backend running on a temporary EC2 machine I have running. The front-end will continue to be served over CDN, but with the form hardcoded to post to the API instance at `api.reclaimers.net`. This is so that I don't have to make major changes to the infrastructure because I intended to revert these changes and shut down the API server once the survey is done.

Survey results are saved by `server.js` into an S3 JSON file. We can download and review the set of results at any time with:

```
curl -s https://reclaimers-data-test.s3.amazonaws.com/survey-results.json | jq
```

Once the survey is complete, we can analyze results and share with the community for interest but I don't think they need to be made permanently available on the wiki, hence the lack of fancy JS visualization of results and such.

## Demo (the API server)
http://api.reclaimers.net:8080/survey/