### PR TITLE
Simplify workflow display in metabox

### DIFF
--- a/src/render/components/workflows.js
+++ b/src/render/components/workflows.js
@@ -68,10 +68,8 @@ const workflowsList = (thisItem, workflows, metaIndex) => {
       items = Object.values(items);
       if (items.length == 1) {
         return `${base}&nbsp;${items[0]}`;
-      } else if (items.length <= 3) {
-        return `${base} ${items.join(", ")}`;
       }
-      return `${base}...${ul(items)}`;
+      return `${base}:${ul(items)}`;
     })
   );
 };


### PR DESCRIPTION
As new tools are added to workflow generation, the results in the metabox have become cluttered; they are unsorted and alternatives are hard to spot at a glance. This change merges similar workflows where the base is identical and only the last items differ. The subgroup is rendered with either an inline single item, comma-separated list of up to 3 items, or a bulleted list if more. Screenshots will do a better job of explaining:

## Screenshots
|Page|Before|After
|---|------|-----
|BSP|![bsp-before](https://user-images.githubusercontent.com/1519264/93173410-53123c80-f6e1-11ea-8698-8a4c045a5f9f.png)|![bsp-after](https://user-images.githubusercontent.com/1519264/93173407-5279a600-f6e1-11ea-93e1-5cbf7cfc5726.png)
|gbxmodel|![gbxmodel-before](https://user-images.githubusercontent.com/1519264/93173415-53aad300-f6e1-11ea-8bd5-2567bdc534cc.png)|![gbxmodel-after](https://user-images.githubusercontent.com/1519264/93173412-53123c80-f6e1-11ea-938e-c23941d55a9a.png)
|jms|![jms-before](https://user-images.githubusercontent.com/1519264/93173417-54436980-f6e1-11ea-9882-dea8b56043d0.png)|![jms-after](https://user-images.githubusercontent.com/1519264/93173416-53aad300-f6e1-11ea-8a16-a13a87eeb0bc.png)
|scenario|![scnr-before](https://user-images.githubusercontent.com/1519264/93173421-54dc0000-f6e1-11ea-82f1-5a04bac26e65.png)|![scnr-after](https://user-images.githubusercontent.com/1519264/93173419-54436980-f6e1-11ea-934f-7bab8092c878.png)


