### PR TITLE
Add a scale converter tool

### DIFF
--- a/src/assets/main.js
+++ b/src/assets/main.js
@@ -1,5 +1,109 @@
 const {html, render, Component} = htmPreact;
 
+class UnitConverter extends Component {
+  constructor() {
+    super();
+    this.handleChange = this.handleChange.bind(this);
+    this.state = {
+      basisType: "world",
+      basisValue: "1",
+    };
+  }
+
+  handleChange(basisType, basisValue) {
+    this.setState({basisType, basisValue});
+  }
+
+  render() {
+    //everything relative to JMS units:
+    const conversions = {
+      jms: {
+        label: "JMS",
+        rel: 1
+      },
+      world: {
+        label: "World units",
+        rel: 100
+      },
+      inches: {
+        label: "Inches",
+        rel: 1 / 1.2
+      },
+      feet: {
+        label: "Feet",
+        rel: 10
+      },
+      meters: {
+        label: "Meters",
+        rel: 1 / 0.03048
+      },
+    };
+
+    const presets = [
+      {
+        label: "Warthog length",
+        basisValue: "191.766",
+        basisType: "jms"
+      },
+      {
+        label: "Player collision height (standing)",
+        basisValue: "70",
+        basisType: "jms"
+      },
+      {
+        label: "Player collision height (crouching)",
+        basisValue: "50",
+        basisType: "jms"
+      },
+      {
+        label: "Distance between Blood Gulch flags",
+        basisValue: "97.60443705836329",
+        basisType: "world"
+      },
+      {
+        label: "American football field length",
+        basisValue: "109.73",
+        basisType: "meters"
+      },
+    ];
+
+    return html`
+      <div class="unit-converter">
+        <div class="inputs">
+          ${Object.entries(conversions).map(([type, {label, rel}]) => {
+            const name = `conversion-${type}`;
+            let entryValue = this.state.basisValue;
+            if (type != this.state.basisType) {
+              const jmsValue = Number(this.state.basisValue) * conversions[this.state.basisType].rel;
+              entryValue = Number.isNaN(jmsValue) ? "" : String(jmsValue / conversions[type].rel);
+            }
+            return html`
+              <br/>
+              <label for=${name}>${label}</label>
+              <input
+                name=${name}
+                type="text"
+                value=${entryValue}
+                onInput=${(e) => this.handleChange(type, e.target.value)}
+              />
+            `;
+          })}
+        </div>
+        <div class="presets">
+          <h2>Presets</h2>
+          ${presets.map(({label, basisValue, basisType}) => {
+            const clickHandler = () => {this.handleChange(basisType, basisValue)};
+            return html`
+              <button onClick=${clickHandler}>${label}</button>
+              <br/>
+            `;
+          })}
+        </div>
+      </div>
+    `;
+  }
+}
+
 class Search extends Component {
   constructor() {
     super();
@@ -133,3 +237,8 @@ class Search extends Component {
 }
 
 render(html`<${Search}/>`, document.getElementById("c20-search-mountpoint"));
+
+const converterMount = document.getElementById("unit-converter-mountpoint");
+if (converterMount) {
+  render(html`<${UnitConverter}/>`, converterMount);
+}

--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -193,6 +193,16 @@ input[type="checkbox"] {
   }
 }
 
+.unit-converter {
+  display: flex;
+  flex-wrap: wrap;
+  .inputs, .presets {
+    flex-grow: 1;
+    flex-basis: 50%;
+    min-width: 15em;
+  }
+}
+
 .radio-options {
   display: flex;
   flex-direction: row;

--- a/src/content/h1/guides/scale/readme.md
+++ b/src/content/h1/guides/scale/readme.md
@@ -1,0 +1,11 @@
+---
+title: Scale and unit conversions
+---
+# Halo's unit types
+* **JMS units** are those used in model tag data. The match 1:1 with the default [3ds max][3dsmax] units and the units in [JMS files][JMS].
+* **World units** are equal to 100 native units. They are often seen in [Guerilla][] and are the coordinates seen when placing objects in [Sapien][].
+
+# Unit converter
+<div id="unit-converter-mountpoint"></div>
+
+<br/>


### PR DESCRIPTION
Adds a new page under the guides section which contains a JS helper for Halo unit conversions. A video of this can be seen in `#tool-mod-art-showcase`.

## Screenshot
![scale](https://user-images.githubusercontent.com/1519264/93635562-5c342f80-f9a7-11ea-8c94-e0f1eeb9b3d7.png)
