### PR TITLE
Add jointed model toolset page

### DIFF
--- a/src/content/general/tools/blender/readme.md
+++ b/src/content/general/tools/blender/readme.md
@@ -8,7 +8,7 @@ keywords:
   - "3d"
   - blend
 ---
-**Blender** is a free and open-source 3D modeling, animating, and rendering toolset. While it has always been possible to transfer assets between 3D software, Blender is a relative newcomer to direct Halo modding workflows, which traditionally relied on the closed-source paid [3ds Max][3dsmax]. Thanks to [community-made plugins][h2v-blender-jms-exporter], it is now possible to use Blender exclusively.
+**Blender** is a free and open-source 3D modeling, animating, and rendering toolset. While it has always been possible to transfer assets between 3D software, Blender is a relative newcomer to direct Halo modding workflows, which traditionally relied on the closed-source paid [3ds Max][3dsmax]. Thanks to [community-made plugins][jointed-model-blender-toolset], it is now possible to use Blender exclusively.
 
 Note that modern Blender 2.8+ is the preferred version, as this will work with available exporters.
 

--- a/src/content/general/tools/h2v-blender-animation-exporter/readme.md
+++ b/src/content/general/tools/h2v-blender-animation-exporter/readme.md
@@ -1,6 +1,0 @@
----
-title: H2V Blender Animation Exporter
-toolName: H2V Blender Animation Exporter
-stub: true
----
-...

--- a/src/content/general/tools/h2v-blender-jms-exporter/readme.md
+++ b/src/content/general/tools/h2v-blender-jms-exporter/readme.md
@@ -1,6 +1,0 @@
----
-title: H2V Blender JMS Exporter
-toolName: H2V Blender JMS Exporter
-stub: true
----
-...

--- a/src/content/general/tools/jointed-model-blender-toolset/readme.md
+++ b/src/content/general/tools/jointed-model-blender-toolset/readme.md
@@ -1,0 +1,22 @@
+---
+title: Jointed Model Blender Toolset
+toolName: Jointed Model Blender Toolset
+stub: true
+info: >
+  * [Source code and download](https://github.com/General-101/Halo-Jointed-Model-Blender-Toolset)
+---
+The **Jointed Model Blender Toolset** is a set of add-ons for [Blender][] which allows the import and export of [JMS][] and [animation data][animation-data] (e.g. JMA) for both [Halo 1][h1] and Halo 2.
+
+# Installation
+To download the add-on from GitHub, choose _Download ZIP_ from the green _Code_ drop-down. There are two ways to install this Plugin:
+
+## Preferences menu
+1. From within Blender, select _Edit > Preferences_.
+2. In the window that appears, select the _Add-ons_ menu and click the _Community_ button.
+3. There now be an _Install..._ button visible, which you should use to choose the `.zip` containing the downloaded add-on.
+4. Finally, ensure that the new add-on is **checked** in the add-ons list.
+
+## Manual installation
+Firstly, you will need to find Blender's `addons` directory. On Windows, this can be found at `%appdata%\Blender Foundation\Blender\<Blender Version>\scripts\addons`. Linux users will find it at `~/.config/blender/<blender version>/scripts/addons`.
+
+Simply extract the downloaded `.zip` to this location so that the `io_scene_halo` directory is contained in `addons`.

--- a/src/content/h1/sources/animation-data/readme.md
+++ b/src/content/h1/sources/animation-data/readme.md
@@ -11,7 +11,7 @@ thanks:
   - to: ODX
     for: JMO frames
 ---
-The [HEK][] uses several file types as intermediate representations of animation data. These files provide a common target for exporters like [Bluestreak][] and [H2V Blender Animation Exporter][h2v-blender-animation-exporter], and can then be converted to [model_animations][] tags by [Tool][] for use in Halo.
+The [HEK][] uses several file types as intermediate representations of animation data. These files provide a common target for exporters like [Bluestreak][] and [Jointed Model Blender Toolset][jointed-model-blender-toolset], and can then be converted to [model_animations][] tags by [Tool][] for use in Halo.
 
 # JMA (Base)
 This is what a lot of animations will end up as. It is a default animation type that stores data necessary for movement, such as a [biped][] walking animation.

--- a/src/data/h1/tools.yml
+++ b/src/data/h1/tools.yml
@@ -62,12 +62,8 @@ workflowItems:
     page: cad-animation-exporter
     authors:
       - CtrlAltDestroy
-  H2V Blender Animation Exporter:
-    page: h2v-blender-animation-exporter
-    authors:
-      - General_101
-  H2V Blender JMS Exporter:
-    page: h2v-blender-jms-exporter
+  Jointed Model Blender Toolset:
+    page: jointed-model-blender-toolset
     authors:
       - General_101
   Blender .gbxmodel Importer:
@@ -475,7 +471,7 @@ similarItems:
   -
     - Blitzkrieg
     - Bluestreak
-    - H2V Blender JMS Exporter
+    - Jointed Model Blender Toolset
     - Blendkrieg
     - CAD animation exporter
     - Chimp
@@ -535,14 +531,14 @@ workflows:
   - using: Blender .gbxmodel Importer
     from: gbxmodel
     to: Blender
-  - using: H2V Blender JMS Exporter
+  - using: Jointed Model Blender Toolset
     from:
       - Blender
       - jms
     to:
       - jms
       - Blender
-  - using: H2V Blender Animation Exporter
+  - using: Jointed Model Blender Toolset
     from: Blender
     to: Animation data
   - using: CAD animation exporter
@@ -664,8 +660,12 @@ workflows:
     from: Animation data
     to: model_animations
   - using: Mozzarilla
-    from: Animation data
-    to: model_animations
+    from:
+      - Animation data
+      - model_animations
+    to:
+      - model_animations
+      - Animation data
   # scenario editing
   - using:
       - Sapien

--- a/src/render/components/workflows.js
+++ b/src/render/components/workflows.js
@@ -47,8 +47,14 @@ const workflowsList = (thisItem, workflows, metaIndex) => {
       //we only want one list item for bi-directional flow pairs
       const hasReverse = workflows.find(other => !flowsEqual(flow, other) && isReverse(other, flow));
       if (hasReverse) {
-        const otherItem = flow.to == thisItem ? flow.from : flow.to;
-        pushLabeledFlow(`bidi-${otherItem}`, `To/from&nbsp;${itemAnchor(otherItem)} with`, flow.using, itemAnchor(flow.using));
+        if (thisItem == flow.using) {
+          const bidiItems = [flow.from, flow.to];
+          bidiItems.sort();
+          pushLabeledFlow(`bidi-${bidiItems[0]}`, `${itemAnchor(bidiItems[0])} to/from`, bidiItems[1], itemAnchor(bidiItems[1]));
+        } else {
+          const otherItem = flow.to == thisItem ? flow.from : flow.to;
+          pushLabeledFlow(`bidi-${otherItem}`, `To/from&nbsp;${itemAnchor(otherItem)} with`, flow.using, itemAnchor(flow.using));
+        }
       } else if (thisItem == flow.from) {
         //use &nbsp; to join words for better appearance on narrow windows
         pushLabeledFlow(`to-${flow.to}`, `To&nbsp;${itemAnchor(flow.to)} with`, flow.using, itemAnchor(flow.using));


### PR DESCRIPTION
General merged together the H2V anim and JMS exports/importers into a single toolset:
https://github.com/General-101/Halo-Jointed-Model-Blender-Toolset

I've now reflected this on the wiki with a new page and updated workflows. The page only covers installation for now.

This PR also fixes a bug when rendering bi-directional workflows where the current page is the "using" part of the workflow; it would previously omit one of the involved workflow items.

![jmt_000](https://user-images.githubusercontent.com/1519264/95030926-c1ef0f80-0667-11eb-9840-e8836ffb02bd.png)
