### PR TITLE
Add bsp cluster sky index notes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2984,9 +2984,9 @@
       }
     },
     "marked": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.0.tgz",
-      "integrity": "sha512-tiRxakgbNPBr301ihe/785NntvYyhxlqcL3YaC8CaxJQh7kiaEtrN9B/eK2I2943Yjkh5gw25chYFDQhOMCwMA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.0.tgz",
+      "integrity": "sha512-NqRSh2+LlN2NInpqTQnS614Y/3NkVMFFU6sJlRFEpxJ/LHuK/qJECH7/fXZjk4VZstPW/Pevjil/VtSONsLc7Q==",
       "dev": true
     },
     "matchdep": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "highlight.js": "^10.4.1",
     "html-entities": "^1.3.1",
     "js-yaml": "^3.13.1",
-    "marked": "^1.2.0",
+    "marked": "^2.0.0",
     "ramda": "^0.27.1",
     "sass": "^1.26.3",
     "viz.js": "^2.1.2"

--- a/src/content/h1/tags/scenario_structure_bsp/page.yml
+++ b/src/content/h1/tags/scenario_structure_bsp/page.yml
@@ -20,3 +20,5 @@ thanks:
     en: Research on weather polyhedra and portals
   Conscars:
     en: Collision BSP structure and phantom BSP research
+  Galap:
+    en: Researching the effect of cluster sky index on lighting

--- a/src/content/h1/tags/sky/page.yml
+++ b/src/content/h1/tags/sky/page.yml
@@ -1,6 +1,9 @@
 title:
   en: sky
 img: sky.jpg
+thanks:
+  Galap:
+    en: Researching the purpose of _affects interiors_
 imgCaption:
   en: >-
     The skybox is a fully 3D object at a much larger scale than the

--- a/src/data/h1/tags/scenario_structure_bsp.yml
+++ b/src/data/h1/tags/scenario_structure_bsp.yml
@@ -393,7 +393,17 @@ comments:
       en: ...
       fields:
         - name: sky
-          en: ...
+          en: |
+            Sets which sky is visible when within this cluster. Indexes the
+            [_skies_][scenario#tag-field-skies] block of the [scenario][] tag,
+            so a value of `0` would mean the first sky, `1` the second, etc. A
+            value of `-1` marks this cluster as indoor/interior for the purposes
+            of certain [sky][] tag fields.
+
+            It is unknown how exactly [Tool][] determines which clusters are indoor
+            when compiling a BSP, but it does validate that all sky faces in a
+            cluster are of the same sky. For example, a cluster cannot contain both
+            `+sky0` and `+sky1` materials.
         - name: fog
           en: ...
         - name: background sound

--- a/src/data/h1/tags/sky.yml
+++ b/src/data/h1/tags/sky.yml
@@ -59,7 +59,10 @@ comments:
             - name: affects exteriors
               en: ...
             - name: affects interiors
-              en: ...
+              en: >
+                If enabled, this light will affect clusters with a
+                [sky index][scenario_structure_bsp#tag-field-clusters-sky] of `-1`,
+                which are considered indoor/interior.
         - name: color
           en: ...
         - name: power


### PR DESCRIPTION
Galap recently did some research in reclaimers about cluster sky index and the "indoor" distinction. I'm capturing that here, also bumping our `marked` dependency to 2.0.0 so dependabot goes away.