### PR TITLE
Size of Halo CE tag space

### DIFF
--- a/src/content/h1/map/readme.md
+++ b/src/content/h1/map/readme.md
@@ -31,7 +31,7 @@ Maps with the extension `.yelo` are compiled with [OS_Tool][opensauce#os-tool] a
 Maps downloaded by the [Chimera][] mod use a custom compressed format taking up less space. These maps are produced by compiling them using [invader-build][invader] with the `-c` flag, or using `invader-compress`. The map's header is uncompressed, but all other data is compressed. These files also have a `.map` extension, but when downloaded directly from [HaloNet][map-sharing#halonet] they have a `.inv` extension. Although Chimera does not download maps to Halo's main `maps` directory, take care not to mix these maps with stock ones since they are not compatible with the base game and are unsupported by other mods at this time. You can, however, decompress them easily with `invader-compresss -d <map>`.
 
 # Limits
-Because the game has a 23 MiB tag space limit (raised to 31 MiB in CEA), [Tool][] will enforce this limit when compiling a map. Keep an eye on its console output:
+Because the game has a 23 MiB tag space limit (22 MiB on Xbox and raised to 31 MiB in CEA), [Tool][] will enforce this limit when compiling a map. Keep an eye on its console output:
 
 ```
 total tag size is 8.43M (14.57M free)
@@ -48,12 +48,17 @@ Within a map, tag _metadata_ (most of the fields seen in tag editors) is stored 
 
 Each section is loaded in a different way:
 
-* Tag metadata is copied directly into memory at a fixed address. On Xbox, PC, and Custom Edition, the game has just 23 MiB of tag space available for the currently loaded map. Tag metadata is loaded into the _start_ of this region. Because this data has been preprocessed by Tool, it requires no further processing and thus is very fast to load. The address where tag data is loaded depends on the edition:
+* Tag metadata is copied directly into memory at a fixed address. The game has a limited amount of tag space available for the currently loaded map. The size depends on the edition:
+  * Xbox: `0x1600000` (22 MiB)
+  * PC/CE: `0x1700000` (23 MiB)
+  * CEA: `0x1f00000` (31 MiB)
+
+  Tag metadata is loaded into the _start_ of this region. Because this data has been preprocessed by Tool, it requires no further processing and thus is very fast to load. The address where tag data is loaded is also dependent on the edition:
   * Xbox: `0x803A6000`
   * Demo: `0x4BF10000`
   * PC/CE: `0x40440000`
   * CEA: `0x40448000`
-* The active BSP is loaded into the _end_ of the 23 MiB tag space. When a BSP switch occurs, the new BSP data is read from the map file and replaces the previous data in-memory. In CEA, it is loaded at memory address `0x41448000` instead.
+* The active BSP is loaded into the _end_ of the tag space. When a BSP switch occurs, the new BSP data is read from the map file and replaces the previous data in-memory. In CEA, it is loaded at memory address `0x41448000` instead.
 * Raw data is streamed from the map file as needed and dynamically allocated in a loaded resource pool/cache. The texture cache is cleared during maps loads and BSP switches. Some tags like [BSPs][scenario_structure_bsp] and [scenarios][scenario] contain a "predicted resources" block which hints to the game which data should be loaded into these caches.
 
 Tags from resource maps are also loaded into the tag space as needed. Halo CEA uses compressed maps and additional files to store sounds and bitmaps, so loads maps [differently][cea#changes].


### PR DESCRIPTION
Hey, seems to be an error on the size of the tag space in memory. The page
currently says 23 MiB but to me it seems to be 22 MiB = 2^20 * 22 = 23068672
bytes.

For example, looking at the second BSP of a10.map on the Xbox version: The
start offset and size of the BSP can be found at the end of the root scenario tag:

    fddc908 <- bsp_file_offset: 5f1800 (u32_le)
    fddc908 <- bsp_size:        7df800 (u32_le)

At offset 05f1800 in a10.map we can find the pointer to the header:

    05f1800 <- sbsp_tag_pointer: 815323c0 (u32_le)

which should point to the sbsp tag that starts with a tag reference to a bitmap
that starts with the engine id "mtib". As the page says, the BSP should be
loaded to the end of the tag space such that the address to the start of the BSP will be

    bsp_mem_addr = TAGS_MEM_ADDR + 22 MiB - bsp_size = 803a6000 + 1600000 - 7df800 = 811c6800

The offset from the start of the BSP to the sbsp tag is then

    sbsp_tag_offset = sbsp_tag_pointer - bsp_mem_addr = 815323c0 - 811c6800 = 36bbc0

We can then calculate the offset to the sbsp tag in the a10.map file as

    sbsp_tag_file_offset = bsp_file_offset + sbsp_tag_offset = 5f1800 + 36bbc0 = 95d3c0

which is where we find our id:

    095d3c0 <- "mtib"

I'm guessing the tag space is also 22 MiB on the PC version but I have no idea what it is for the Anniversary edition, the page currently says it is 31 MiB = 32505856 bytes.
