### PR TITLE
Mention release section instead of github repo

### DIFF
--- a/src/content/general/tools/jointed-model-blender-toolset/readme.md
+++ b/src/content/general/tools/jointed-model-blender-toolset/readme.md
@@ -1,7 +1,7 @@
 The **Jointed Model Blender Toolset** is a set of add-ons for [Blender][] which allows the import and export of [JMS][] and [animation data][animation-data] (e.g. JMA) for both [Halo 1][h1] and [Halo 2][h2].
 
 # Installation
-To download the add-on from GitHub, choose _Download ZIP_ from the green _Code_ drop-down. There are two ways to install this Plugin:
+To download the add-on from GitHub, press the _tags_ link next to the branch name on the top left. Switch to the release tab and download the latest release. The zip you want will be in the panel labeled _Assets_ and will start with the name _halo-asset-blender-toolset_. There are two ways to install this Plugin:
 
 ## Preferences menu
 1. From within Blender, select _Edit > Preferences_.


### PR DESCRIPTION
Zips from release should just work when installing from the addon menu. Github actions will now handle new releases.