### PR TITLE
Allow ffmpeg to be optional build dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ An explicit choice was made to avoid typical managed or self-hosted Wiki platfor
 * [Marked.js](https://github.com/markedjs/marked) for Markdown rendering. This library is extremely customizable; we customize header rendering to support anchor links and have a plaintext renderer to support search and opengraph previews.
 
 ### Building and testing
-In order to see content as it will appear online, you can run c20 in development mode. As a pre-requisite, this project requires [installing Node.js v14+](https://nodejs.org/en/), [FFmpeg](https://ffmpeg.org/), and [Git LFS](https://git-lfs.github.com/).
+In order to see content as it will appear online, you can run c20 in development mode. As a pre-requisite, this project requires installing at least [Node.js v14+](https://nodejs.org/en/) and [Git LFS](https://git-lfs.github.com/)
+
+[FFmpeg](https://ffmpeg.org/) is an optional dependency used to generate video thumbnails. It needs to be available on your system `PATH`, or Windows users can simply download `ffmpeg.exe` and place it in the project root. If you don't want to set up FFmpeg for development you can set the environment variable `C20_NO_THUMBNAILS=true` and it won't be used.
 
 If you have installed Git LFS _after_ checking out the project already, you'll need to run `git lfs install` and `git lfs pull` to download the objects. If you forget to do this the build will fail because `ffmpeg` will be unable to read video files as videos ("Invalid data found when processing input").
 
@@ -61,6 +63,9 @@ npm ci
 
 # build content into `./dist`
 npm run dev
+
+# if you don't want to rely on ffmpeg
+C20_NO_THUMBNAILS=true npm run dev
 ```
 
 You should be able to visit http://localhost:8080/ in a browser and see the built website. The website will be automatically rebuilt if you make changes to source content. Refresh your browser to see changes.

--- a/src/build/render/components/bits.js
+++ b/src/build/render/components/bits.js
@@ -4,6 +4,7 @@ const R = require("ramda");
 const DISCORD_URL = "https://discord.reclaimers.net";
 const REPO_URL = "https://github.com/Sigmmma/c20";
 const DEFAULT_OPEN_THRESHOLD = 8;
+const noThumbs = process.env.C20_NO_THUMBNAILS == "true";
 
 const breakTagName = (tagName) => tagName.split("_").join("_<wbr>");
 
@@ -128,7 +129,7 @@ const figure = (href, caption, inline) => html`
 `;
 
 const video = (href, poster) => html`
-  <video controls preload="${poster ? "none" : "auto"}" ${poster ? `poster="${poster}"` : null}>
+  <video controls preload="${poster && !noThumbs ? "none" : "auto"}" ${poster && !noThumbs ? `poster="${poster}"` : null}>
     <source src="${href}" type="video/mp4">
   </video>
 `;

--- a/src/build/render/components/markdown/plaintext-renderer.js
+++ b/src/build/render/components/markdown/plaintext-renderer.js
@@ -23,7 +23,7 @@ module.exports = function(ctx) {
   renderer.br = () => "\n";
   renderer.del = (text) => text;
   renderer.link = (href, title, text) => text;
-  renderer.image = (href, title, text) => `(${title})`;
+  renderer.image = (href, title, text) => title ? `(${title})` : "";
   renderer.text = (text) => text;
   //blocks:
   renderer.code = (code, infostring, escaped) => {

--- a/src/build/resources.js
+++ b/src/build/resources.js
@@ -7,6 +7,7 @@ const vizRenderOpts = require("viz.js/full.render.js");
 const COPY_FILES_PATTERN = /\.(jpg|jpeg|png|gif|ms|mp4)/;
 const VIDEO_FILES_PATTERN = /\.(mp4)/;
 const VIZ_RENDER_PATTERN = /\.(dot|neato|fdp|sfdp|twopi|circo)/;
+const noThumbs = process.env.C20_NO_THUMBNAILS == "true";
 
 //todo: this does extra work then the URL is not localized but there are multiple languages
 async function buildResources(pageIndex, buildOpts) {
@@ -51,13 +52,13 @@ async function buildResources(pageIndex, buildOpts) {
           await fs.writeFile(destPath, svg, "utf8");
         }));
       }
-      if (ext.match(VIDEO_FILES_PATTERN)) {
+      if (ext.match(VIDEO_FILES_PATTERN) && !noThumbs) {
         await Promise.all(destLangs.map(async (lang) => {
           const destPath = path.join(buildOpts.outputDir, page.localizedPaths[lang], `${name}.thumb_%d.jpg`);
           await new Promise((resolve, reject) => {
             exec(`ffmpeg -i "${srcPath}" -vframes 1 "${destPath}"`, (err) => {
               if (err) reject(err);
-              else resolve(files);
+              else resolve();
             });
           });
         }));


### PR DESCRIPTION
This change allows an environment variable `C20_NO_THUMBNAILS=true` to be set which makes ffmpeg and video thumbnails an optional part of the build. Without it, videos will simply rely on browser autoload behaviour to cache the first few seconds of video for the preview.