### PR TITLE
Add more H1 renderer limits

### DIFF
--- a/src/content/h1/engine/renderer/max-light-surfaces.jpg
+++ b/src/content/h1/engine/renderer/max-light-surfaces.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5bdec9a74db29f36d62328fe8c8f38783c2de5f2b7b5d535e6e2f560552f556
+size 86278

--- a/src/content/h1/engine/renderer/readme.md
+++ b/src/content/h1/engine/renderer/readme.md
@@ -69,12 +69,17 @@ _Most_ of these issues have now been corrected in DX11 renderer in [H1A][h1a] MC
   * The "normal" _type_ may<sup>(unconfirmed)</sup> incorrectly mask primary and secondary detail maps when an alpha is present in the base map, visible in b40 exterior tech wall.
 
 # Limits
+![.figure Dynamic lights cause parts of the BSP to be rendered in another pass, but only 4096 triangles per light. High-poly spaces may reach this limit.](max-light-surfaces.jpg)
+
 Known renderer limits with the _unmodified_ game are:
 
 * [Particle_system][] particles: 256
 * Non-particle system [particles][particle]: 512
 * [Objects][object]: 256 (raised to 512 in H1A)
 * [BSP triangles][scenario_structure_bsp]: 16k (raised to 32k in H1A) -- a BSP can have more triangles than this, but the rendered amount should be managed with portals.
+* [Lights][light]: 128
+* Surfaces per point light: 4096 -- limits how many triangles can be illuminated by a dynamic light (see figure)
+* Maximum dynamic triangles: 32k -- unknown exactly what this entails
 
 There are also [game state limits][game-state#limits] which can appear like renderer limitations (eg. maximum simulated antennas).
 


### PR DESCRIPTION
We got some info from Korn about H1 renderer limits. This updates the renderer page accordingly:

![Screenshot 2021-11-02 230813](https://user-images.githubusercontent.com/1519264/140016140-229dd4f2-68d9-4ccb-840c-ff785ee7ecc6.png)
