### PR TITLE
h1/map ResourceMapType: fix enum values

### DIFF
--- a/src/content/h1/map/readme.md
+++ b/src/content/h1/map/readme.md
@@ -159,7 +159,7 @@ The tag index/tag data header is the start of where tag data and definitions are
 ```.struct
 entry_type: TagDataHeaderPC
 showOffsets: true
-id: resource-header
+id: tag-header
 imports:
   h1/files/map:
     - TagDataHeaderPC
@@ -171,7 +171,7 @@ The H1X tag index header is slightly different since model data is also in the t
 ```.struct
 entry_type: TagDataHeaderXbox
 showOffsets: true
-id: resource-header
+id: xbox-tag-header
 imports:
   h1/files/map:
     - TagDataHeaderXbox
@@ -183,7 +183,7 @@ Each 32-byte element in the tag array contains information about a tag in the ma
 ```.struct
 entry_type: TagArrayEntry
 showOffsets: true
-id: resource-header
+id: tag-entry
 imports:
   h1/files/map:
     - TagArrayEntry

--- a/src/data/structs/h1/files/map.yml
+++ b/src/data/structs/h1/files/map.yml
@@ -236,12 +236,15 @@ type_defs:
     size: 4
     options:
       - name: bitmaps
+        value: 1
         comments:
           en: The file contains [bitmap][] tags.
       - name: sounds
+        value: 2
         comments:
           en: The file contains [sound][] tags.
       - name: loc
+        value: 3
         comments:
           en: The file contains [font][] and [unicode_string_list][] tags.
   ResourceMapResource:


### PR DESCRIPTION
According to the current page, the values for the ResourceMapType enum in the resource header are:
- bitmap: 0
- sounds: 1
- loc: 2

However, each value seems to be off by one compared to the actual values in the files. The type field is the very first 4 bytes of the file, it can be examined with e.g hexdump:
```
$ for f in bitmaps.map sounds.map loc.map; do md5sum $f; hexdump $f -n4; done
28b5432675965c47d12c57ad59c79502  bitmaps.map
0000000 0001 0000
0000004
8ce8d469e363f769acdf678b14588ec4  sounds.map
0000000 0002 0000
0000004
962fdc043c7b66cb1f7fe30e79b3b2fc  loc.map
0000000 0003 0000
0000004
```

I also noticed some struct ids were not updated when copied, the first commit fixes this. The second commit fixes the enum values.