### PR TITLE
Document mounted weapon units limit

### DIFF
--- a/src/content/h1/engine/game-state/readme.md
+++ b/src/content/h1/engine/game-state/readme.md
@@ -51,3 +51,4 @@ Since the game world is dynamic, the datum count can rise up to a limit. The fol
 |hs globals (includes "external globals", not just those in the level script)|1024|-|
 |recorded animations|64|-|
 |[AI knowledge][ai#knowledge-model]|768|-|
+|[mounted weapon units][unit#tag-field-seats-built-in-gunner]|8|-|

--- a/src/data/structs/h1/tags/unit.yml
+++ b/src/data/structs/h1/tags/unit.yml
@@ -292,6 +292,12 @@ type_defs:
         meta:
           tag_classes:
             - actor_variant
+        comments:
+          en: >-
+            Used to place a mounted weapon unit at this seat, which aims and
+            fires independently of this unit. An example is the bottom-mounted
+            turret on the covenant dropship. The game can only simulate [up to
+            8][game-state] of these mounted units at a time.
       - type: pad
         size: 20
   Unit:


### PR DESCRIPTION
Sapien can warn when opening a30 that `MAXIMUM_NUMBER_OF_MOUNTED_WEAPON_UNITS` has been exceeded due to the covie dropship gunners. I've been informed this limit is 8.