### PR TITLE
Document H1 dialogue tag

### DIFF
--- a/EDITORS.md
+++ b/EDITORS.md
@@ -224,6 +224,8 @@ columns:
   # and more columns...
 ```
 
+Inline markdown tables can be given automatic width like `noClear` by surrounding them with `<div class="no-clear">...</div>` tags.
+
 ### Alert boxes
 An alert box is a highlighted container which draws attention to some content, usually text. It can be added with the following syntax:
 

--- a/src/assets/_tables.scss
+++ b/src/assets/_tables.scss
@@ -5,7 +5,7 @@ table {
   margin-bottom: var(--padding-sm);
   width: 100%;
 
-  &.no-clear {
+  &.no-clear, .no-clear & {
     width: auto;
   }
 

--- a/src/content/h1/tags/dialogue/page.yml
+++ b/src/content/h1/tags/dialogue/page.yml
@@ -1,4 +1,9 @@
 title:
   en: dialogue
-stub: true
+img: woohoo.jpg
+imgCaption:
+  en: Woohoo!
 tagName: h1/dialogue
+thanks:
+  1SDAN:
+    en: Listing canonical character dialogue tags

--- a/src/content/h1/tags/dialogue/readme.md
+++ b/src/content/h1/tags/dialogue/readme.md
@@ -1,1 +1,41 @@
-...
+The **dialogue** tag group gives [units][unit] situational sounds, like when they take damage, see allies die, or are startled. Dialogue usage is not just limited to AI bipeds; it's responsible for the player's death sounds and can even be referenced for vehicles, though not all situations apply. Dialogue is an important part of Halo's game design and helps communicate the internal state of characters to the player.
+
+The randomization of voice lines is not part of the dialogue tag but rather the referenced [sound][] tags, which can contain multiple permutations.
+
+# Canonical character dialogue tags
+The following stock dialogue tags correspond to canonical characters:
+
+<div class="no-clear">
+
+| Character | Tag path
+|-----------|----------
+| 343 Guilty Spark | `sound\dialog\monitor\monitor`
+| Jacob Keyes | `sound\dialog\captain\captain`
+| Avery Johnson | `sound\dialog\sargeant\conditional\sargeant`
+| Marcus Stacker | `sound\dialog\sarge2\conditional\sarge2`
+| Chips Dubbo | `sound\dialog\marines\aussie\conditional\aussie`
+| Private Bisenti | `sound\dialog\marines\bisenti\conditional\bisenti`
+| M. Fitzgerald  | `sound\dialog\marines\fitzgerald\conditional\fitzgerald`
+| Manuel Mendoza  | `sound\dialog\marines\mendoza\conditional\mendoza`
+
+</div>
+
+Additional level-specific character sound tags, e.g. for cinematics, can be found under the `sound\dialog\x**` folders.
+
+# Related script functions and globals
+The following are related [functions][scripting#functions] that you can use in your scenario scripts and/or [debug globals][scripting#external-globals] that you can enter into the developer console for troubleshooting.
+
+```.table
+id: functions-globals
+dataPath:
+  - hsc/h1/functions/functions
+  - hsc/h1/globals/external_globals
+linkCol: true
+linkSlugKey: slug
+rowSortKey: slug
+rowTagFilter: dialogue
+columns:
+  - key: info/en
+    name: Function/global
+    format: text
+```

--- a/src/content/h1/tags/dialogue/woohoo.jpg
+++ b/src/content/h1/tags/dialogue/woohoo.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2c179f026b92fd9f00f0469a54b0bb4df53563e21f6989eec53572be63817e4
+size 17393

--- a/src/data/hsc/h1/functions.yml
+++ b/src/data/hsc/h1/functions.yml
@@ -365,7 +365,11 @@ functions:
         (ai_dialogue_triggers true)
         (ai_dialogue_triggers false)
         ```
-        Turns impromptu dialogue on or off
+        Turns impromptu [dialogue][h1/tags/dialogue] on or off. When off,
+        units will still play some sounds (like when they take damage) but will
+        not speak when exiting vehicles, seeing friends die, etc.
+    tags:
+      - dialogue
   - slug: ai_disregard
     info:
       en: >-

--- a/src/data/hsc/h1/globals.yml
+++ b/src/data/hsc/h1/globals.yml
@@ -459,6 +459,10 @@ external_globals:
         ```hsc
         (ai_render_dialogue_variants)
         ```
+        Shows pink text overlays over each unit with [dialogue][h1/tags/dialogue]
+        showing which variant they use, like if marines are a "mendoza" or a "bisenti".
+    tags:
+      - dialogue
   - slug: ai_render_emotions
     info:
       en: |-

--- a/src/data/tags/h1.yml
+++ b/src/data/tags/h1.yml
@@ -214,6 +214,8 @@ dialogue:
   structName: Dialogue
   structModule: h1/tags/dialogue
   id: udlg
+  description:
+    en: Gives units situational sounds, such as when taking damage or fleeing.
 projectile:
   structName: Projectile
   structModule: h1/tags/projectile


### PR DESCRIPTION
The H1 dialogue page was an empty stub but no longer. Includes some info from `#wiki-dump` and some in-game testing.