### PR TITLE
Changed H3 and ODST pages to reflect inclusion of mapinfo files

### DIFF
--- a/src/content/h3/h3-ek/h3-standalone-build/readme.md
+++ b/src/content/h3/h3-ek/h3-standalone-build/readme.md
@@ -107,5 +107,4 @@ You can quickly spawn a variety of objects for testing:
 
 # Known issues & Fixes
 * Sound doesn't play - Copy over the `fmod` folder from your install of H3 or ODST depending on which game you are working on.
-* Maps can't be loaded using the UI - see [#Usage][h3-standalone-build#usage] for a workaround.
 * Levels that make use of the script function `soft_ceiling_enable` will cause scripts to fail to compile due to post processing not done by standalone. You can fix this by setting the script global `scenario_load_all_tags` to true. The only level known to be affected by this is `110_hc` otherwise known as the singleplayer level named `Cortana`.

--- a/src/content/h3/h3-ek/readme.md
+++ b/src/content/h3/h3-ek/readme.md
@@ -135,7 +135,6 @@ Naturally there is multitude of changes compared to H2 as the engine underwent a
 * Halo 3 custom maps requires that the map info matches the map it is replacing to load. This means having the same campaign and map ID. These values can be found at the top of the scenario tag.
 * Single threaded lightmapping is not supported, you need to use the multi-process solution. This can be run with only a single client if only using one core is desired.
 * Sound playback and sound importing require the FSB files that come with MCC in order to function. Copy the FSB files from your Halo 3 MCC install.
-* The mainmenu requires the mapinfo files that come with MCC in order to load levels. Otherwise you will need to use `init.txt` or the developer console to load scenarios in the standalone build.
 * Guerilla uses red text and greyed out folders for all tags - this doesn't mean there is something wrong with your tags it's just a graphical issue.
 * Lipsync won't be generated when importing sounds that use a multilingual sound class such as unit_dialog as third party tools are required.
 * Forging objects while using the Standalone client will cause a crash. A workaround is to use the main menu to launch Forge from the lobby.

--- a/src/content/h3/h3-ek/readme.md
+++ b/src/content/h3/h3-ek/readme.md
@@ -30,6 +30,7 @@ Unlike the [H1A-EK][] you ***do*** need to own [Halo 3 on Steam][steam_purchase]
 
 * Various changes to tags and data files. Updating your tag set is highly recommended.
 * Added test, audio and lighting reference scenarios `levels\test\box`, `levels\reference\audio`, `levels\reference\lighting_reference`
+* Map info files have been added to the `H3EK.7z` which allows the main menu to load maps.
 
 ## General
 

--- a/src/content/h3odst/h3odst-ek/readme.md
+++ b/src/content/h3odst/h3odst-ek/readme.md
@@ -80,7 +80,6 @@ Naturally there is multitude of changes compared to H2 as the engine underwent a
 * Halo 3 ODST custom maps requires that the map info matches the map it is replacing to load. This means having the same campaign and map ID. These values can be found at the top of the scenario tag.
 * Single threaded lightmapping is not supported, you need to use the multi-process solution. This can be run with only a single client if only using one core is desired.
 * Sound playback and sound importing require the FSB files that come with MCC in order to function. Copy the FSB files from your Halo 3 ODST MCC install.
-* The mainmenu requires the mapinfo files that come with MCC in order to load levels. Otherwise you will need to use `init.txt` or the developer console to load scenarios in the standalone build.
 * Guerilla uses red text and greyed out folders for all tags - this doesn't mean there is something wrong with your tags it's just a graphical issue.
 * Lipsync won't be generated when importing sounds that use a multilingual sound class such as unit_dialog as third party tools are required.
 

--- a/src/content/h3odst/h3odst-ek/readme.md
+++ b/src/content/h3odst/h3odst-ek/readme.md
@@ -27,6 +27,7 @@ Unlike the [H1A-EK][] you ***do*** need to own [Halo 3 ODST on Steam][steam_purc
 
 * Various changes to tags and data files. Updating your tag set is highly recommended.
 * Added test, audio and lighting reference scenarios `levels\test\box`, `levels\reference\audio`, `levels\reference\lighting_reference`
+* Map info files have been added to the `H3ODSTEK.7z` which allows the main menu to load maps.
 
 ### General
 

--- a/src/content/hr/hr-ek/hr-standalone-build/readme.md
+++ b/src/content/hr/hr-ek/hr-standalone-build/readme.md
@@ -107,5 +107,3 @@ You can quickly spawn a variety of objects for testing:
 
 # Known issues & Fixes
 * Sound doesn't play - Copy over the `fmod` folder from your install of Reach.
-* Maps can't be loaded using the UI - see [#Usage][hr-standalone-build#usage] for a workaround.
-* Levels that make use of the script function `soft_ceiling_enable` will cause scripts to fail to compile due to post processing not done by standalone. You can fix this by setting the script global `scenario_load_all_tags` to true. The only level known to be affected by this is `110_hc` otherwise known as the singleplayer level named `Cortana`.

--- a/src/content/hr/hr-ek/page.yml
+++ b/src/content/hr/hr-ek/page.yml
@@ -6,6 +6,6 @@ imgCaption:
     Foundation level editor and MegaloEdit game type editor.
 info:
   en: >
-    * Release date: TBA
+    * Release date: September 2022
 stub: true
 toolName: HR-EK

--- a/src/content/hr/hr-ek/readme.md
+++ b/src/content/hr/hr-ek/readme.md
@@ -22,7 +22,7 @@ Unlike the [H1A-EK][] you ***do*** need to own [Halo Reach on Steam][steam_purch
 # Major changes from H3
 Naturally there is multitude of changes compared to H3 as the engine underwent a major revision, this document endeavours to list the major ones.
 
-* Bonobo takes the place of Guerilla as the kit's tag editor with a completely new UI that makes it easier than ever before to create and modify tags.
+* Foundation takes the place of Guerilla as the kit's tag editor with a completely new UI that makes it easier than ever before to create and modify tags.
 * Structures can no longer be created using [ASS][] files, you need to use GR2 files.
 
 # Known issues
@@ -32,7 +32,6 @@ Naturally there is multitude of changes compared to H3 as the engine underwent a
 * Halo Reach custom maps requires that the map info matches the map it is replacing to load. This means having the same campaign and map ID. These values can be found at the top of the scenario tag.
 * Single threaded lightmapping is not supported, you need to use the multi-process solution. This can be run with only a single client if only using one core is desired.
 * Sound playback and sound importing require the FSB files that come with MCC in order to function. Copy the FSB files from your Halo Reach MCC install.
-* The mainmenu requires the mapinfo files that come with MCC in order to load levels. Otherwise you will need to use `init.txt` or the developer console to load scenarios in the standalone build.
 * All the stock tags do not contain import info so you will not be able to extract source assets that way.
 
 [steam_purchase]: https://store.steampowered.com/app/1064220


### PR DESCRIPTION
As of the September update the H3 and ODST zipped files contain the map info files for the maps in the editing kit allowing the main menu to load these maps without having to copy the files from MCC. Also removed/changed some erroneous  info on Reach pages.