### PR TITLE
Document object lighting

### DIFF
--- a/src/content/h1/tags/object/readme.md
+++ b/src/content/h1/tags/object/readme.md
@@ -24,7 +24,7 @@ For most dynamic objects, Halo uses [shadow mapping][shadow-mapping] with their 
 
 Objects receive a few parameters from [the environment](~lightmaps#lighting-for-dynamic-objects) as inputs to their lighting model. These include up to two distant light sources (direction and colour), ambient light, reflection tint, shadow direction, and shadow colour. Lighting is calculated when objects are created and also when dynamic objects move. To do this the game casts a ray straight down to a BSP _ground point_ up to 10 world units away to determine its lighting and can result in a few scenarios:
 
-1. If a ground point is found within 10 units, that surface's lightmap colour is used to light the object. This is why even an object in direct sunlight can appear dark when it is sampling the ground _beneath_ it. The source of the shadow vector is unknown. In this scenario you will see a coloured vector drawn over objects with `debug_object_lights 1`.
+1. If a ground point is found within 10 units, that surface's lightmap colour is used to light the object. This is why even an object in direct sunlight can appear dark when it is sampling the ground _beneath_ it. The shadow vector is an interpolation of lightmap vertex normals. In this scenario you will see a coloured vector drawn over objects with `debug_object_lights 1`.
 2. If a ground point is not found and the BSP tag has a non-zero red value for [_default ambient color_ field](~scenario_structure_bsp#tag-field-default-distant-light-0-color), BSP default lighting fields will apply.
 2. Otherwise the object receives hard-coded white light from the +x +y direction and casts shadows straight down.
 

--- a/src/content/h1/tags/object/readme.md
+++ b/src/content/h1/tags/object/readme.md
@@ -19,11 +19,23 @@ Some capabilities available to objects (though not used by every subtype) are:
 * Have attachments like [particles](~particle_system), [sounds](~sound_looping), and [lights](~light)
 * Be attached to each other (e.g. pelicans carrying warthogs)
 
-# Shadows
-For most dynamic objects, Halo uses [shadow mapping][shadow-mapping] with their render [model](~gbxmodel), unless the object's ["does not cast shadow"](#tag-field-flags-does-not-cast-shadow) flag is true. However, with [scenery](~), shadows are baked into the [lightmap](~scenario_structure_bsp) using the object's [collision geometry](~model_collision_geometry) instead, regardless of the "does not cast shadow" flag.
+# Shadows and lighting
+For most dynamic objects, Halo uses [shadow mapping][shadow-mapping] with their [render model](~gbxmodel), unless the object's ["does not cast shadow"](#tag-field-flags-does-not-cast-shadow) flag is true. However, with [scenery](~), shadows are baked into the [lightmap](~lightmaps) using the object's [collision geometry](~model_collision_geometry) instead, regardless of the "does not cast shadow" flag.
 
-[shadow-mapping]: https://en.wikipedia.org/wiki/Shadow_mapping
+Objects receive a few parameters from [the environment](~lightmaps#lighting-for-dynamic-objects) as inputs to their lighting model. These include up to two distant light sources (direction and colour), ambient light, reflection tint, shadow direction, and shadow colour. Lighting is calculated when objects are created and also when dynamic objects move. To do this the game casts a ray straight down to a BSP _ground point_ up to 10 world units away to determine its lighting and can result in a few scenarios:
+
+1. If a ground point is found within 10 units, that surface's lightmap colour is used to light the object. This is why even an object in direct sunlight can appear dark when it is sampling the ground _beneath_ it. The source of the shadow vector is unknown. In this scenario you will see a coloured vector drawn over objects with `debug_object_lights 1`.
+2. If a ground point is not found and the BSP tag has a non-zero red value for [_default ambient color_ field](~scenario_structure_bsp#tag-field-default-distant-light-0-color), BSP default lighting fields will apply.
+2. Otherwise the object receives hard-coded white light from the +x +y direction and casts shadows straight down.
+
+You can test the latter two scenarios by setting `debug_collision_skip_vectors 1` to make the ray cast always fail. Scenery which are outside the BSP will also fail to get a ground point and therefore receive default lighting.
+
+# Related HaloScript
+
+{% relatedHsc game="h1" tagFilter="object" /%}
 
 # Structure and fields
 
 {% tagStruct "h1/object" /%}
+
+[shadow-mapping]: https://en.wikipedia.org/wiki/Shadow_mapping

--- a/src/content/h1/tags/physics/readme.md
+++ b/src/content/h1/tags/physics/readme.md
@@ -6,6 +6,7 @@ caption: The mass points of a Warthog.
 thanks:
   Kavawuvi: Invader tag definitions
   MosesOfEgypt: Tag structure research
+  Conscars: Mass point node testing
 ---
 **Physics** tags characterize the dynamic physics and propulsion of [vehicles](~vehicle). They are essentially a collection of spherical _mass points_. Since vehicles can have both [model_collision_geometry](~) and physics, each tag is used in different situations:
 
@@ -20,11 +21,15 @@ Physics tags are created by [compiling a JMS](~tool) with specially-named<sup>(h
 # Mass points
 Mass points (also known as physics spheres) are spherical volumes with mass and density. They can have various types of friction and may provide powered impulse for flight and driving.
 
-Even though mass points are parented to nodes, they do not move with base, overlay, or aiming animations unlike [model_collision_geometry](~). However, when mass points are parented to nodes they can be used to engage a vehicle's suspension animation (e.g. the Warthog and Scorpion). The animation tag specifies the compression and extension depth. It is unknown if the mass points move with the node in this case.
+Even though mass points are parented to nodes, they do not move with base, overlay, or aiming animations unlike [model_collision_geometry](~). However, when mass points are parented to nodes they can be used to engage a vehicle's suspension animation (e.g. the Warthog and Scorpion). The animation tag specifies the compression and extension depth. The mass points move with the node in this case.
 
-[bouncy]: https://youtu.be/Vz48n5jZaQ8?t=1
-[stuck-bsp]: https://youtu.be/n5uN1RuOVRM?t=22
+# Related HaloScript
+
+{% relatedHsc game="h1" tagFilter="physics" /%}
 
 # Structure and fields
 
 {% tagStruct "h1/physics" /%}
+
+[bouncy]: https://youtu.be/Vz48n5jZaQ8?t=1
+[stuck-bsp]: https://youtu.be/n5uN1RuOVRM?t=22

--- a/src/content/h1/tags/scenario_structure_bsp/lightmaps/readme.md
+++ b/src/content/h1/tags/scenario_structure_bsp/lightmaps/readme.md
@@ -8,6 +8,8 @@ keywords:
   - lightmap
   - radiosity
   - bake
+thanks:
+  Conscars: Object lighting tests
 ---
 **Lightmaps** are a combination of data storing the static "baked" lighting of a [BSP](~scenario_structure_bsp). Since the BSP does not move, and many shadow-casting objects like [scenery](~) have fixed locations, base [global illumination][global-illumination] can be precalculated. Dynamic objects will cast [shadow-mapped][shadow-mapping] shadows and be lit using lightmap data at runtime.
 
@@ -24,9 +26,9 @@ If higher resolution or greater control of lighting is desired, [Aether](~) faci
 [Sky](~sky) lights, emissive [environment shaders](~shader), scenery with [lights](~light), and [light fixtures](~device_light_fixture) can all be used as light sources to illuminate the BSP. If you change any of these inputs, or move any scenery, you must re-run radiosity.
 
 # Lighting for dynamic objects
-All [objects](~object) receive their lighting from the environment using data in the BSP, generated during radiosity. Similar to light probes in other engines, this data encodes the shadow direction and incoming light of locations throughout the BSP.
+All [objects](~object) usually receive their lighting from the environment using data in the BSP tag generated during radiosity. See object [shadows and lighting](~object#shadows-and-lighting).
 
-Only moving objects like [units](~unit) cast real-time shadows; [scenery](~) cast shadows in the baked lightmap using the object's [collision model](~model_collision_geometry) rather than its [render model](~gbxmodel), likely because the collision model is stored using a BSP structure which is more efficient to perform lighting calculations with.
+Only moving objects like [units](~unit) cast real-time shadows; [scenery](~) cast shadows in the baked lightmap using the object's [collision model](~model_collision_geometry) rather than its [render model](~gbxmodel), likely because the collision model is stored using a BSP structure which is more efficient to perform lighting calculations with. Dynamic shadows will only be rendered if the ground point lightmap sample is bright enough or when default lighting applies.
 
 # Related script functions and globals
 The following are related [functions](~scripting#functions) that you can use in your scenario scripts and/or [debug globals](~scripting#external-globals) that you can enter into the developer console for troubleshooting.

--- a/src/data/hsc/h1/globals.yml
+++ b/src/data/hsc/h1/globals.yml
@@ -1226,7 +1226,7 @@ external_globals:
         (collision_debug_flag_structure [boolean])
         ```
         Toggles if collision debug rays collide with the [structure BSP](~scenario_structure_bsp).
-        Collisions with [model_collision_geometry] BSPs are unaffected.
+        Collisions with [model_collision_geometry](~) BSPs are unaffected.
   - slug: collision_debug_flag_try_to_keep_location_valid
     info:
       en: |-
@@ -1494,10 +1494,10 @@ external_globals:
         Globally disables vector/ray collision tests, with the following observed effects:
         - [Projectiles](~projectile), [particles](~particle) and moving [items](~item) will pass through everything, even the BSP.
         - Melees will have no effect.
-        - [Vehicle] suspension, such as the Warthog's wheels, will hang.
-        - [Object lighting](~renderer#lighting) will be unable to determine if an object
-          exists in direct sunlight from the [sky](~), resulting in incorrect lighting
-          and shadow direction when an object moves.
+        - [Vehicle](~) suspension, such as the Warthog's wheels, will hang.
+        - [Object lighting](~renderer#lighting) will be unable to determine the
+          ground point below the object when it moves, resulting in incorrect
+          lighting and shadow direction.
         - [Sounds](~sound) behind obstructions will not be muffled.
   - slug: debug_damage
     tags:
@@ -1529,9 +1529,9 @@ external_globals:
         (debug_decals)
         ```
         Displays red numbers over each dynamic and permanent decal in the
-        environment. The mesh of the most recently created dynamic
-        decal will also be highlighted so you can see how it conforms around the
-        BSP.
+        environment. The mesh of the most recently created decal (initially a
+        permanent decal if one exists, then any new dynamic one) will also be
+        highlighted so you can see how it conforms around the BSP.
         
         White points indicate the original 4 corners of the decal, while
         red ones were added during the conformation to the BSP. The meaning of
@@ -1673,12 +1673,21 @@ external_globals:
         (debug_object_garbage_collection)
         ```
   - slug: debug_object_lights
+    tags:
+      - object
+      - lightmaps
     info:
       en: |-
         ```hsc
         (debug_object_lights)
         ```
+        Shows the incoming light colour and vector for all objects which results
+        from [sampling lightmap data](~lightmaps#lighting-for-dynamic-objects)
+        at the ground point beneath the object. This data is used to shade the
+        object and cast its shadow.
   - slug: debug_objects
+    tags:
+      - object
     info:
       en: |-
         ```hsc
@@ -1688,6 +1697,8 @@ external_globals:
         (such as bounding sphere and collision models). Individual debug
         features can be toggled with the `debug_objects_*` commands.
   - slug: debug_objects_biped_autoaim_pills
+    tags:
+      - object
     info:
       en: |-
         ```hsc
@@ -1702,6 +1713,8 @@ external_globals:
         (debug_objects_biped_messages)
         ```
   - slug: debug_objects_biped_physics_pills
+    tags:
+      - object
     info:
       en: |-
         ```hsc
@@ -1710,6 +1723,8 @@ external_globals:
         When `debug_objects` is enabled, displays
         [biped physics pills](~biped#physics-and-autoaim-pills) in white.
   - slug: debug_objects_bounding_spheres
+    tags:
+      - object
     info:
       en: |-
         ```hsc
@@ -1721,6 +1736,7 @@ external_globals:
         in H1CE Sapien but not H1A Sapien.
   - slug: debug_objects_collision_models
     tags:
+      - object
       - model_collision_geometry
     info:
       en: |-
@@ -1743,6 +1759,8 @@ external_globals:
         (debug_objects_equipment_messages)
         ```
   - slug: debug_objects_names
+    tags:
+      - object
     info:
       en: |-
         ```hsc
@@ -1752,6 +1770,7 @@ external_globals:
         The names are shown in purple.
   - slug: debug_objects_pathfinding_spheres
     tags:
+      - object
       - model_collision_geometry
     info:
       en: |-
@@ -1761,17 +1780,26 @@ external_globals:
         When `debug_objects` is enabled, displays object [pathfinding spheres](~model_collision_geometry#pathfinding-spheres)
         in blue.
   - slug: debug_objects_physics
+    tags:
+      - object
+      - physics
     info:
       en: |-
         ```hsc
         (debug_objects_physics)
         ```
+        When `debug_objects` is enabled, displays [physics](~) mass points as white spheres. 
   - slug: debug_objects_position_velocity
+    tags:
+      - object
+      - physics
     info:
       en: |-
         ```hsc
         (debug_objects_position_velocity)
         ```
+        When `debug_objects` is enabled, displays red, green, and blue object-space
+        reference axes and a yellow velocity vector on each object.
   - slug: debug_objects_projectile_messages
     info:
       en: |-
@@ -1779,11 +1807,16 @@ external_globals:
         (debug_objects_projectile_messages)
         ```
   - slug: debug_objects_root_node
+    tags:
+      - object
     info:
       en: |-
         ```hsc
         (debug_objects_root_node)
         ```
+        When `debug_objects` is enabled, displays red, green, and blue object-space
+        reference axes and orange text including object ID, class, and tag name
+        on each object. Defaults to `true` in H1A.
   - slug: debug_objects_unit_mouth_apeture
     info:
       en: |-
@@ -1791,17 +1824,29 @@ external_globals:
         (debug_objects_unit_mouth_apeture)
         ```
   - slug: debug_objects_unit_seats
+    tags:
+      - object
+      - vehicle
+      - unit
     info:
       en: |-
         ```hsc
         (debug_objects_unit_seats)
         ```
+        When `debug_objects` is enabled, displays blue markers at unit seat
+        locations, red markers at their entry points, and a yellow marker at the
+        object origin.
   - slug: debug_objects_unit_vectors
+    tags:
+      - object
+      - physics
     info:
       en: |-
         ```hsc
         (debug_objects_unit_vectors)
         ```
+        When `debug_objects` is enabled, displays white and red vectors on
+        objects. Their meaning is unknown.
   - slug: debug_objects_vehicle_messages
     info:
       en: |-
@@ -1814,6 +1859,7 @@ external_globals:
         ```hsc
         (debug_objects_vehicle_powered_mass_points)
         ```
+        No visible effect, even with `debug_objects_physics` enabled.
   - slug: debug_objects_weapon_messages
     info:
       en: |-
@@ -2389,29 +2435,48 @@ external_globals:
         (network_connect_timeout)
         ```
   - slug: object_light_ambient_base
+    tags:
+      - object
     info:
       en: |-
         ```hsc
         (object_light_ambient_base)
         ```
+        Sets the amount of ambient light all objects receive. Note that this
+        only affects moving objects when their lighting updates, so you will
+        not see any change on scenery. Setting this to `1` makes objects
+        fullbright. Defaults to `0.03`.
   - slug: object_light_ambient_scale
+    tags:
+      - lightmaps
+      - object
     info:
       en: |-
         ```hsc
         (object_light_ambient_scale)
         ```
+        Scales ambient light from the lightmap. Defaults to `0.4`.
   - slug: object_light_interpolate
+    tags:
+      - lightmaps
+      - object
     info:
       en: |-
         ```hsc
         (object_light_interpolate)
         ```
+        Toggles if [object lighting](~lightmaps#lighting-for-dynamic-objects) transitions smoothly when the object moves
+        between different ground point surfaces or default lighting.
   - slug: object_light_secondary_scale
+    tags:
+      - object
     info:
       en: |-
         ```hsc
         (object_light_secondary_scale)
         ```
+        Scales secondary light on objects, but doesn't apply to default lighting.
+        Defaults to `1`.
   - slug: object_prediction
     info:
       en: |-

--- a/src/data/structs/h1/tags/common.yml
+++ b/src/data/structs/h1/tags/common.yml
@@ -609,3 +609,13 @@ type_defs:
     bits:
       - name: blend in hsv
       - name: more colors
+  VertexType:
+    class: enum
+    size: 2
+    options:
+      - name: structure_bsp_uncompressed_rendered_vertices
+      - name: structure_bsp_compressed_rendered_vertices
+      - name: structure_bsp_uncompressed_lightmap_vertices
+      - name: structure_bsp_compressed_lightmap_vertices
+      - name: model_uncompressed
+      - name: model_compressed

--- a/src/data/structs/h1/tags/scenario_structure_bsp.yml
+++ b/src/data/structs/h1/tags/scenario_structure_bsp.yml
@@ -15,6 +15,7 @@ imports:
     - TagString
     - Quaternion
     - Point2D
+    - VertexType
   h1/tags/model_collision_geometry:
     - ModelCollisionGeometryBSP
 type_defs:
@@ -146,20 +147,31 @@ type_defs:
         type: Index
       - type: pad
         size: 2
-      - name: do_not_screw_up_the_model
-        type: uint32
+      - name: rendered_vertices_type
+        type: VertexType
         meta:
-          h1x_only: true
           cache_only: true
         endianness: little
         comments:
-          en: '(Xbox only) if this isn''t set to 1, then the world ends'
+          en: Indicates how rendered vertices are stored.
+      - type: pad
+        size: 2
       - name: rendered_vertices_count
         type: uint32
       - name: rendered_vertices_offset
         type: uint32
-      - type: pad
-        size: 4
+        comments:
+          en: |-
+            An offset to an array of rendered vertices, each 56 bytes:
+            * Position
+            * Normal
+            * Binormal
+            * Tangent
+            * UV
+      - name: unknown_pointer
+        type: ptr32
+        meta:
+          runtime: true
         comments:
           en: >-
             on PC, this gets changed to a pointer to something when the BSP is
@@ -172,20 +184,24 @@ type_defs:
         endianness: little
         comments:
           en: (Xbox only) an indirect pointer to the rendered vertices
-      - name: set_this_or_die
-        type: uint32
+      - name: lightmap_vertices_type
+        type: VertexType
         meta:
-          h1x_only: true
           cache_only: true
         endianness: little
         comments:
-          en: >-
-            (Xbox only) if this isn't set to 3, then the visible lightmap UVs do
-            not work
+          en: Indicates how lightmap vertices are stored.
+      - type: pad
+        size: 2
       - name: lightmap_vertices_count
         type: uint32
       - name: lightmap_vertices_offset
         type: uint32
+        comments:
+          en: |-
+            An offset to an array of lightmap vertices, each 20 bytes:
+            * Normal (used for dynamic object shadows)
+            * UV
       - type: pad
         size: 4
       - name: lightmap_vertices_index_pointer

--- a/src/data/structs/h1/tags/scenario_structure_bsp.yml
+++ b/src/data/structs/h1/tags/scenario_structure_bsp.yml
@@ -870,24 +870,43 @@ type_defs:
         size: 20
       - name: default_ambient_color
         type: ColorRGB
+        comments:
+          en: |-
+            If the red component of this colour is non-zero, this and all
+            following default lighting fields will be used to light objects when
+            a ground point does not exist within 10wu below them.
       - type: pad
         size: 4
       - name: default_distant_light_0_color
         type: ColorRGB
+        comments:
+          en: Primary distant light colour when default lighting applies.
       - name: default_distant_light_0_direction
         type: Vector3D
+        comments:
+          en: Primary distant light direction when default lighting applies.
       - name: default_distant_light_1_color
         type: ColorRGB
+        comments:
+          en: Secondary distant light colour when default lighting applies.
       - name: default_distant_light_1_direction
         type: Vector3D
+        comments:
+          en: Secondary distant light direction when default lighting applies.
       - type: pad
         size: 12
       - name: default_reflection_tint
         type: ColorARGB
+        comments:
+          en: Reflection tint when default lighting applies.
       - name: default_shadow_vector
         type: Vector3D
+        comments:
+          en: Shadow vector when default lighting applies.
       - name: default_shadow_color
         type: ColorRGB
+        comments:
+          en: Shadow colour when default lighting applies.
       - type: pad
         size: 4
       - name: collision_materials


### PR DESCRIPTION
Closes https://github.com/Sigmmma/c20/issues/179

The main goal of this PR was to explain how objects are lit using lightmaps. There are still some mysteries like how light and shadow directions are calculated when not under default lighting situations.