### PR TITLE
Change HR ManagedAPI to not use TagsOnly initialization

### DIFF
--- a/src/content/hr/API/readme.md
+++ b/src/content/hr/API/readme.md
@@ -27,7 +27,6 @@ namespace Sample
 
             };
             var param = new ManagedBlamStartupParameters();
-            param.InitializationLevel = InitializationType.TagsOnly;
             // e.g. G:\SteamLibrary\steamapps\common\HREK
             Bungie.ManagedBlamSystem.Start(@"<path to HREK install>", del, param);
 


### PR DESCRIPTION
For some reason this causes an exception to occur when using TagFile.New() or after loading 3 tags.