### PR TITLE
More comments, some H1A additions

### DIFF
--- a/src/data/structs/h1/tags/actor_variant.yml
+++ b/src/data/structs/h1/tags/actor_variant.yml
@@ -18,6 +18,9 @@ type_defs:
     size: 4
     bits:
       - name: can_shoot_while_flying
+        comments:
+          en: >
+            Also allows grounded AIs to shoot while jumping or falling.
       - name: interpolate_color_in_hsv
         comments:
           en: >
@@ -253,6 +256,10 @@ type_defs:
         type: float
         meta:
           unit: seconds
+        comments:
+          en: >
+            How long this AI follows "New target" firing modifiers when first
+            engaging a target.
       - name: surprise_delay_time
         type: float
         meta:

--- a/src/data/structs/h1/tags/scenario.yml
+++ b/src/data/structs/h1/tags/scenario.yml
@@ -1115,8 +1115,8 @@ type_defs:
       - name: none
         comments:
           en: >
-            Use same behaviour previously defined. Used for starting locations,
-            or empty squads meant for migration
+            Retain behaviour previously defined. Used for starting locations,
+            or empty squads meant for migration.
       - name: sleeping
         comments:
           en: >

--- a/src/data/structs/h1/tags/scenario.yml
+++ b/src/data/structs/h1/tags/scenario.yml
@@ -64,6 +64,12 @@ type_defs:
           unused: true
         comments:
           en: Unused at this time.
+      - name: do_not_apply_bungie_campaign_tag_patches
+        meta:
+          h1a_only: true
+        comments:
+          en: >
+            Disables the [hardcoded tag patches](~tool#hardcoded-tag-patches)
   ScenarioChildScenario:
     class: struct
     assert_size: 32
@@ -174,9 +180,22 @@ type_defs:
     size: 2
     bits:
       - name: automatically
+        comments:
+          en: >
+            This object does not exist on map start and must be created by a script.
       - name: on_easy
+        meta:
+          unused: true
+        comments:
+          en: >
+            Has no effect on spawning. Use scripts to control difficulty-specific
+            spawning of non-actor objects.
       - name: on_normal
+        meta:
+          unused: true
       - name: on_hard
+        meta:
+          unused: true
   SpawnPrelude:
     class: struct
     assert_size: 32
@@ -374,6 +393,10 @@ type_defs:
       - name: initially_at_rest
       - name: obsolete
       - name: does_accelerate
+        comments:
+         en: >
+           Can be moved by impulses like explosions.
+           Grenades with this flag can be detonated.
   ScenarioEquipment:
     class: struct
     extends:
@@ -634,6 +657,9 @@ type_defs:
         meta:
           min: 0
           max: 3
+        comments:
+          en: >
+            Values above 1 give Overshield layers.
       - name: primary_weapon
         type: TagDependency
         meta:
@@ -1063,6 +1089,9 @@ type_defs:
     size: 2
     options:
       - name: default_by_unit
+        comments:
+          en: >
+            Uses the default team defined in the unit's biped tag.
       - name: player
       - name: human
       - name: covenant
@@ -1239,10 +1268,17 @@ type_defs:
         type: Index
         meta:
           index_of: platoons
-      - name: Tinitial_state
+      - name: initial_state
         type: ScenarioReturnState
-      - name: Treturn_state
+        comments:
+          en: >
+            The squad's or unit's behaviour when initially placed.
+      - name: return_state
         type: ScenarioReturnState
+        comments:
+          en: >
+            The squad's or unit's behaviour when it has been alerted
+            but has since completely lost track of any living enemies.
       - name: flags
         type: ScenarioSquadFlags
       - name: unique_leader_type
@@ -1255,32 +1291,65 @@ type_defs:
         size: 2
       - name: maneuver_to_squad
         type: Index
+        comments:
+          en: >
+            What squad to switch to when maneuvering is triggered,
+            whether by platoon conditions or by a script.
       - name: squad_delay_time
         type: float
       - name: attacking
         type: ScenarioSquadAttacking
+        comments:
+          en: >
+            Which firing positions to use when shooting at enemies.
       - name: attacking_search
         type: ScenarioSquadAttacking
+        comments:
+          en: >
+            Which firing positions to look for a target that's broken
+            line of sight with the squad.
       - name: attacking_guard
         type: ScenarioSquadAttacking
+        comments:
+          en: >
+            Which firing positions to use for the inital/return states
+            "guarding" or "guarding at guard position".
       - name: defending
         type: ScenarioSquadAttacking
+        comments:
+          en: >
+            As above, but used in the defending state.
       - name: defending_search
         type: ScenarioSquadAttacking
       - name: defending_guard
         type: ScenarioSquadAttacking
       - name: pursuing
         type: ScenarioSquadAttacking
+        meta:
+          unused: true
+        comments:
+          en: >
+            AIs never use these firing positions; this field can be left blank.
       - type: pad
         size: 4
       - type: pad
         size: 8
       - name: normal_diff_count
         type: uint16
+          en: >
+            Hoe many actors to spawn on Easy and Normal.
       - name: insane_diff_count
         type: uint16
+        comments:
+          en: >
+            How many actors to spawn on Legendary. Heroic uses the average of
+            this and the previous value.
       - name: major_upgrade
         type: ScenarioMajorUpgrade
+        comments:
+          en: >
+            Along with difficulty level, influences how many actors in the squad
+            will spawn as their major variants instead.
       - type: pad
         size: 2
       - name: respawn_min_actors
@@ -1311,6 +1380,10 @@ type_defs:
           T: ScenarioActorStartingLocation
         meta:
           hek_max_count: 32
+        comments:
+          en: >
+            Squads need at least one valid starting position for units to spawn.
+            If there are more units than valid locations, they will be reused.
       - type: pad
         size: 12
   ScenarioPlatoonFlags:
@@ -1334,6 +1407,10 @@ type_defs:
       - name: 75_dead
       - name: all_but_one_dead
       - name: all_dead
+    comments:
+      en: >
+        Strength is the fraction of total HP across all members
+        of the platoon
   ScenarioPlatoon:
     class: struct
     assert_size: 172
@@ -1610,6 +1687,10 @@ type_defs:
           max: 65534
       - type: pad
         size: 24
+      - comments:
+          en: >
+            Sets of predefined actions for actors to take
+            upon being spawned.
   ScenarioAIAnimationReference:
     class: struct
     assert_size: 60
@@ -2137,7 +2218,7 @@ type_defs:
           en: >-
             Determines the type of map this scenario represents. This also causes
             map compilers like Tool and invader to apply certain
-            [hardcoded tag patches](~tool#hardcoded-tag-patches).
+            [hardcoded tag patches](~tool#hardcoded-tag-patches), but see below in H1A.
       - name: flags
         type: ScenarioFlags
       - name: child_scenarios

--- a/src/data/structs/h1/tags/scenario.yml
+++ b/src/data/structs/h1/tags/scenario.yml
@@ -1113,17 +1113,44 @@ type_defs:
     size: 2
     options:
       - name: none
+        comments:
+          en: >
+            Use same behaviour previously defined. Used for starting locations,
+            or empty squads meant for migration
       - name: sleeping
+        comments:
+          en: >
+            Actors will only be alerted by sounds or physical contact,
+            and will use sleeping animations if they have any.
       - name: alert
+        comments:
+          en: >
+            Actors will stand still and look forward.
       - name: moving_repeat_same_position
+        comments:
+          en: >
+            These and the following behaviours use [move positions](#tag-field-encounters-squads-move-positions) defined
+            in squad data to determine where to move. Use casual walking animations if applicable.
       - name: moving_loop
       - name: moving_loop_back_and_forth
       - name: moving_loop_randomly
       - name: moving_randomly
       - name: guarding
+        comments:
+          en: >
+            Choose one guard firing position and move there, remaining alert afterward.
       - name: guarding_at_guard_position
+        comments:
+          en: >
+            Randomly move between guard firing positions, using running animations.
       - name: searching
+        comments:
+          en: >
+            Randomly move between search firing positions, using searching walking animations.
       - name: fleeing
+        comments:
+          en: >
+            Randomly move between firing positions, using fleeing animations.
   ScenarioSquadFlags:
     class: bitfield
     size: 4
@@ -1376,6 +1403,9 @@ type_defs:
           T: ScenarioMovePosition
         meta:
           hek_max_count: 64
+        comments:
+          en: >
+            Used for actor initial and return states, eg as patrol routes.
       - name: starting_locations
         type: Block
         type_args:
@@ -2217,7 +2247,7 @@ type_defs:
       - name: type
         type: ScenarioType
         comments:
-          en: >-
+          en: >
             Determines the type of map this scenario represents. This also causes
             map compilers like Tool and invader to apply certain
             [hardcoded tag patches](~tool#hardcoded-tag-patches), but see below in H1A.

--- a/src/data/structs/h1/tags/scenario.yml
+++ b/src/data/structs/h1/tags/scenario.yml
@@ -1302,12 +1302,14 @@ type_defs:
         comments:
           en: >
             Which firing positions to use when shooting at enemies.
+            Actors will further discriminate between firing positions
+            based on cover provided, proximity of allies or foes, etc.
       - name: attacking_search
         type: ScenarioSquadAttacking
         comments:
           en: >
-            Which firing positions to look for a target that's broken
-            line of sight with the squad.
+            Which firing positions to use when looking for a target
+            that's broken line of sight with the squad.
       - name: attacking_guard
         type: ScenarioSquadAttacking
         comments:

--- a/src/data/structs/h1/tags/scenario.yml
+++ b/src/data/structs/h1/tags/scenario.yml
@@ -69,7 +69,7 @@ type_defs:
           h1a_only: true
         comments:
           en: >
-            Disables the [hardcoded tag patches](~tool#hardcoded-tag-patches)
+            Disables the [hardcoded tag patches](~tool#hardcoded-tag-patches).
   ScenarioChildScenario:
     class: struct
     assert_size: 32
@@ -189,7 +189,7 @@ type_defs:
         comments:
           en: >
             Has no effect on spawning. Use scripts to control difficulty-specific
-            spawning of non-actor objects.
+            spawning of objects.
       - name: on_normal
         meta:
           unused: true
@@ -1442,7 +1442,7 @@ type_defs:
     comments:
       en: >
         Strength is the fraction of total HP across all members
-        of the platoon
+        of the platoon.
   ScenarioPlatoon:
     class: struct
     assert_size: 172

--- a/src/data/structs/h1/tags/weapon.yml
+++ b/src/data/structs/h1/tags/weapon.yml
@@ -82,13 +82,16 @@ type_defs:
     options:
       - name: always
         comments:
-          en: No effect.
+          en: >
+             Movement is penalized at all times while held.
       - name: when_zoomed
         comments:
-          en: No effect.
+          en: >
+            Movement is penalized only when zoomed in.
       - name: when_zoomed_or_reloading
         comments:
-          en: No effect.
+          en: >
+            **Bugged.** Movement is penalized only when _not_ reloading.
   WeaponType:
     class: enum
     size: 2
@@ -207,9 +210,9 @@ type_defs:
       - name: sticks_when_dropped
         comments:
           en: >
-            If true the weapon will keep the trigger state from the time it was
-            dropped. If it was being held while dropped it will continue being
-            held.
+            If true the weapon's trigger will be held down when it is dropped,
+            regardless of whether it was held down by the wielder at the time.
+            These dropped weapons will expend ammunition but not build up age.
       - name: ejects_during_chamber
       - name: discharging_spews
       - name: analog_rate_of_fire
@@ -781,25 +784,34 @@ type_defs:
         size: 4
       - name: movement_penalized
         type: WeaponMovementPenalized
+        meta:
+          h1a_only: true
         comments:
           en: >
-            **Unused**. This was meant to slow the player when using certain
-            weapons like the rocket launcher, but it has no effect ingame
-            regardless of the options, penalty values used, or game mode.
+            Present in previous versions, but has no effect in them. Reduces or
+            inverts player movement by a fraction when this weapon is held. 
       - type: pad
         size: 2
       - name: forward_movement_penalty
         type: Fraction
         comments:
-          en: No effect.
+          en: >
+            The fraction of movement speed lost when moving forward or backward.
+            A value of 1.0 prevents movement. Values greater than 1.0 invert input,
+            up to 2.0 which gives full movement speed in the opposite direction.
       - name: sideways_movement_penalty
         type: Fraction
         comments:
-          en: No effect.
+          en: >
+            As above, but for movement from side to side.
       - type: pad
         size: 4
       - name: minimum_target_range
         type: float
+        comments:
+          en: >
+            AI actors will not use this weapon's primary trigger
+            on targets below this range.
       - name: looking_time_modifier
         type: float
       - type: pad

--- a/src/data/structs/h1/tags/weapon.yml
+++ b/src/data/structs/h1/tags/weapon.yml
@@ -200,7 +200,8 @@ type_defs:
         comments:
           en: >
             Makes the trigger behave like a switch. Tap it to turn it on. Tap it
-            again to turn it off.
+            again to turn it off. While on, weapon will continue firing while
+            meleeing or throwing grenades, when dropped, and when switched.
       - name: projectiles_use_weapon_origin
         comments:
           en: >
@@ -810,8 +811,8 @@ type_defs:
         type: float
         comments:
           en: >
-            AI actors will not use this weapon's primary trigger
-            on targets below this range.
+            AI actors will not fire this weapon on targets below this range;
+            but Overcharge [special fire mode](~#tag-field-special-fire-mode-overcharge) will ignore this setting.
       - name: looking_time_modifier
         type: float
       - type: pad

--- a/src/data/structs/h1/tags/weapon.yml
+++ b/src/data/structs/h1/tags/weapon.yml
@@ -831,7 +831,7 @@ type_defs:
         comments:
           en: >
             AI actors will not fire this weapon on targets below this range;
-            but Overcharge [special fire mode](~#tag-field-special-fire-mode-overcharge) will ignore this setting.
+            but Overcharge [special fire mode](~actor_variant#tag-field-special-fire-mode-overcharge) will ignore this setting.
       - name: looking_time_modifier
         type: float
       - type: pad

--- a/src/data/structs/h1/tags/weapon.yml
+++ b/src/data/structs/h1/tags/weapon.yml
@@ -201,7 +201,8 @@ type_defs:
           en: >
             Makes the trigger behave like a switch. Tap it to turn it on. Tap it
             again to turn it off. While on, weapon will continue firing while
-            meleeing or throwing grenades, when dropped, and when switched.
+            meleeing or throwing grenades, when dropped, and when switched,
+            firing in unexpected directions in the latter two states.
       - name: projectiles_use_weapon_origin
         comments:
           en: >
@@ -216,12 +217,22 @@ type_defs:
             These dropped weapons will expend ammunition but not build up age.
       - name: ejects_during_chamber
       - name: discharging_spews
+        comments:
+          en: >
+            If true and the trigger is set to discharge on overcharge, will
+            automatically fire every tick for the duration of spew time.
       - name: analog_rate_of_fire
       - name: use_error_when_unzoomed
         comments:
           en: |
-            Makes the trigger always fire completely accurately when zoomed in.
+            Makes the trigger always fire completely accurately when zoomed in,
+            disregarding the triggers' defined error values.
       - name: projectile_vector_cannot_be_adjusted
+        comments:
+          en: >
+            Forces projectiles to be fired in the direction the gun (more precisely
+            the gun's trigger marker) is facing, rather than the direction the
+            wielder is looking. Most relevant for vehicle-mounted weapons.
       - name: projectiles_have_identical_error
         comments:
           en: >
@@ -266,6 +277,10 @@ type_defs:
     size: 2
     options:
       - name: point
+        comments:
+          en: >
+            Causes projectiles' firing angle to be randomly offset by a number
+            between the minimum error and the current error angle (see below).
       - name: horizontal_fan
         comments:
           en: >
@@ -301,6 +316,10 @@ type_defs:
             - effect
       - name: firing_damage
         type: TagDependency
+        comments:
+          en: >
+            Damage effect applied to the wielder when a shot
+            is normally fired. Used for camera shaking, etc.
         meta:
           tag_classes:
             - damage_effect

--- a/src/data/structs/h1/tags/weapon_hud_interface.yml
+++ b/src/data/structs/h1/tags/weapon_hud_interface.yml
@@ -163,10 +163,21 @@ type_defs:
         type: int8
       - name: sequence_index
         type: Index
+        comments:
+          en: >
+            For HUD bitmaps which are split into multiple parts
+            or "sequences," specifies which sequence to use. 0-indexed.
       - name: alpha_multiplier
         type: int8
+          en: >
+            The difference in alpha mask values from one round in an
+            ammo meter to the next. This value times the number of
+            rounds in the magazine cannot exceed 255.
       - name: alpha_bias
         type: int8
+          en: >
+            When nonzero, offsets the starting value of alpha mask in
+            a meter to (255-alpha bias). Can usually be left at zero.
       - name: value_scale
         type: int16
       - name: opacity
@@ -568,12 +579,25 @@ type_defs:
         size: 2
       - name: total_ammo_cutoff
         type: uint16
+        comments:
+          en: >
+            When the reserve ammo is below this amount, flash.
       - name: loaded_ammo_cutoff
         type: uint16
+        comments:
+          en: >
+            When the ammo in the magazine is below this amount, flash.
       - name: heat_cutoff
         type: uint16
+        comments:
+          en: >
+            When the weapon heat is above this amount, flash.
       - name: age_cutoff
         type: uint16
+        comments:
+          en: >
+            When the weapon has aged this much (eg for plasma weapon
+            batteries), flash.
       - type: pad
         size: 32
       - name: anchor

--- a/src/data/structs/h1/tags/weapon_hud_interface.yml
+++ b/src/data/structs/h1/tags/weapon_hud_interface.yml
@@ -177,7 +177,8 @@ type_defs:
         type: int8
           en: >
             When nonzero, offsets the starting value of alpha mask in
-            a meter to (255-alpha bias). Can usually be left at zero.
+            a meter to (255-alpha bias). Can usually be left at zero
+            or 255 minus the alpha mask of the first round.
       - name: value_scale
         type: int16
       - name: opacity


### PR DESCRIPTION
Adds explanatory comments to more tag fields, mostly in the scenario and weapon tags. Also adds a few H1A-exclusive tag fields and behaviours.

Thanks to FD for info on how and when the different types of encounter firing positions are used.