### PR TITLE
H1A: Workshop Modding

### DIFF
--- a/src/content/h1/h1a/readme.md
+++ b/src/content/h1/h1a/readme.md
@@ -16,7 +16,7 @@ One of its quirks is the ability to switch between classic and remastered/annive
 As of season 7, H1A represents a merger between the original H1CE and H1PC branches of the engine.
 
 # Modding
-H1A officially supports modding with the release of the upgraded [H1A Editing Kit](~h1a-ek). The editing kit can be downloaded via Steam and used to make custom maps. At this time, users must turn EAC off and replace existing stock maps with custom ones in order to play them.
+H1A officially supports modding with the release of the upgraded [H1A Editing Kit](~h1a-ek). The editing kit can be downloaded via Steam and used to make custom maps. As of now, users are able to play custom maps with the use of the Steam Workshop, as long as MCC is launched with EAC off.
 
 # Changes
 The H1A engine saw some adjustments to the [map](~) format. This made it difficult for some existing [modding programs](~tools) to read the new format.


### PR DESCRIPTION
The modding section has been updated in mind of the inclusion of the Steam Workshop.
**No more stock map replacing!**

I suggest the addition of a link for the Workshop, but I haven't figured out yet on where do they reside in the repository.