### PR TITLE
Added fix info for cubemap compression

### DIFF
--- a/src/content/h3/guides/map-making/dynamic-cubemaps/K.png
+++ b/src/content/h3/guides/map-making/dynamic-cubemaps/K.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cdcb2a6503e42bc8a8bb2861650fdf3ecba7e162d46b310ff7d0410457a09a3d
+size 424596

--- a/src/content/h3/guides/map-making/dynamic-cubemaps/L.png
+++ b/src/content/h3/guides/map-making/dynamic-cubemaps/L.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0d236f51aafc1c16b4bdea023aa35549cce85e508d21439fa135a6ad75f211b
+size 420074

--- a/src/content/h3/guides/map-making/dynamic-cubemaps/readme.md
+++ b/src/content/h3/guides/map-making/dynamic-cubemaps/readme.md
@@ -8,6 +8,8 @@ keywords:
   - reflections
 thanks:
   Kashiiera: Writing this guide
+  PepperMan: \"Fixing highly-compressed cubemaps\" section
+  J-S: Original discovery of HDR cubemap compression fix
 ---
 
 # Introduction
@@ -84,6 +86,22 @@ For example with a scenario named `test` and a BSP named `030_030`, the bitmap b
 ![](G.png "")
 
 If you have multiple BSPs setup in your scenario, make sure to assign the correct cubemaps bitmap to each one.
+
+## Fixing highly-compressed cubemaps
+Occasionally (and for currently unknown reasons), tool may produce cubemaps that look incredibly low quality, with bad colour compression. See
+this example:
+![](K.png "Horrible compression artifacting.")
+
+This can be fixed, but only *before* cubemap generation.
+1. Before you use the `cubemap_dynamic_generate` cubemap command, open the debug menu with the {% key "Home" /%} key.
+2. Press {% key "4" /%} to enter the `Graphics` sub-menu.
+3. Press {% key "4" /%} to enter the `Rasterizer` sub-menu.
+4. Use the arrow keys to navigate to the `HDR Multiplier (stops)` option.
+5. Use the left arrow key to reduce the value of this option to zero.
+6. Now exit out of the debug menu (use {% key "Home" /%} or {% key "End" /%}) and continue with the rest of the process as normal.
+
+Once you have finished re-generating and re-importing the cubemaps, they should be much better quality! See the following example:
+![](L.png "Note the huge difference in colour quality, especially in the clouds.")
 
 # End result
 


### PR DESCRIPTION
Small additional section for fixing the horrible colour compression that can occur for unknown reasons when generating cubemaps, with example before/after images. Credited J-S for originally finding and bringing to my attention