### PR TITLE
Add information about rename.txt

### DIFF
--- a/src/content/h1/source-data/rename-txt/readme.md
+++ b/src/content/h1/source-data/rename-txt/readme.md
@@ -1,8 +1,14 @@
 ---
-title: rename.txt
+title: Text file for reusing animations
 about: 'resource:Animation data'
+keywords: 
+  - animation
+  - copy
+  - duplicate
+  - rename
+  - reuse
 thanks:
-  Abstract Ingenuity: Research and documentation
+  "Abstract Ingenuity": Research and documentation
 ---
 
 The file `rename.txt` is for reusing animations under different names.
@@ -15,14 +21,16 @@ After importing all the animations, Tool will try to parse `rename.txt` and modi
 
 # Format
 
-Each line in `readme.txt` is written like this:  
+To reuse an animation as another animation, write a line in this format:
 ```
 name-of-animation = name-of-animation
 ```
 
 There are three parts: the name of an animation that does not already exist, the equal sign, and the name of an animation that does exist.
 
-[H1CE Tool](~h1/tools/hek/tool) considers any spaces around the equal sign as part of the animations' names. Files typically are not named with leading spaces or trailing spaces. That means having spaces there likely will be a problem for Tool. [H1A Tool](~h1/tools/h1a-ek/h1a-tool) ignores any spaces around the equal sign.
+[H1CE Tool](~tool) considers any spaces around the equal sign as part of the animations' names. Files typically do not have spaces at the beginning or at the end of their names. For most situations, do not add any spaces around the equal sign. The name of the animation will be incorrect. If the name is not correct, Tool will fail to find the animation. 
+
+[H1A Tool](~h1a-tool) seems to ignore spaces around the equal sign. They are not considered as part of the animations' names. 
 
 # Example
 

--- a/src/content/h1/source-data/rename-txt/readme.md
+++ b/src/content/h1/source-data/rename-txt/readme.md
@@ -1,0 +1,70 @@
+---
+title: rename.txt
+about: 'resource:Animation data'
+thanks:
+  Abstract Ingenuity: Research and documentation
+---
+
+The file `rename.txt` is for reusing animations under different names.
+
+# Usage
+
+Source data files for animations go in a subfolder named `animations` as described [here](~tool#animation-compilation). Create a text file named `rename` in that folder. Open the file in a text editor, make any necessary changes, then save.
+
+After importing all the animations, Tool will try to parse `rename.txt` and modify the [model_animations](~) tag according to the contents of the file.
+
+# Format
+
+Each line in `readme.txt` is written like this:  
+```
+name-of-animation = name-of-animation
+```
+
+There are three parts: the name of an animation that does not already exist, the equal sign, and the name of an animation that does exist.
+
+[H1CE Tool](~h1/tools/hek/tool) considers any spaces around the equal sign as part of the animations' names. Files typically are not named with leading spaces or trailing spaces. That means having spaces there likely will be a problem for Tool. [H1A Tool](~h1/tools/h1a-ek/h1a-tool) ignores any spaces around the equal sign.
+
+# Example
+
+Source data files
+```
+first-person firing.JMM
+first-person idle.JMM
+first-person light-off.JMM
+first-person melee.JMM
+first-person moving.JMO
+first-person overlays.JMO
+first-person posing.JMM
+first-person put-away.JMM
+first-person ready.JMM
+first-person reload-full.JMM
+first-person reload-full2.JMM
+first-person stealth-melee.JMM
+first-person throw-grenade.JMM
+rename.txt
+```
+
+Contents of `rename.txt`
+```
+first-person reload-empty=first-person reload-full
+```
+
+Output from [Tool](~tool#animation-compilation)
+```
+### first-person firing.JMM
+### first-person idle.JMM
+### first-person light-off.JMM
+### first-person melee.JMM
+### first-person posing.JMM
+### first-person put-away.JMM
+### first-person ready.JMM
+### first-person reload-full.JMM
+### first-person reload-full2.JMM
+### first-person stealth-melee.JMM
+### first-person throw-grenade.JMM
+### first-person moving.JMO
+### first-person overlays.JMO
+renamed "first-person reload-full" ==> "first-person reload-empty"
+
+model animation compression saved 0 bytes
+```

--- a/src/content/h1/tools/h1a-ek/h1a-tool/readme.md
+++ b/src/content/h1/tools/h1a-ek/h1a-tool/readme.md
@@ -55,7 +55,9 @@ tool animations "characters\cyborg"
 
 For the example above, Tool would expect to find corresponding animation data files at `data\characters\cyborg\animations\`. Assuming no errors, it would be compiled into `tags\characters\cyborg\cyborg.model_animations`.
 
-See the [animation data](~animation-data) page for more info on the various extensions used during animation importing and their purpose.
+Animation data files can have different extensions. That depends on the type of animation they are intended to be. See the [animation data](~animation-data) page for information about the various extensions and the different types of animation.
+
+Add [rename.txt](~rename-txt) to reuse animations as other animations, without copying and renaming files.
 
 # Bitmap compilation
 Compile a single TIFF image into a [bitmap](~) using the `bitmap` verb:

--- a/src/content/h1/tools/hek/tool/readme.md
+++ b/src/content/h1/tools/hek/tool/readme.md
@@ -61,7 +61,9 @@ tool.exe animations "characters\cyborg"
 
 For the example above, Tool would expect to find corresponding animation data files at `data\characters\cyborg\animations\`. Assuming no errors, it would be compiled into `tags\characters\cyborg\cyborg.model_animations`.
 
-See the [animation data](~animation-data) page for more info on the various extensions used during animation importing and their purpose.
+Animation data files can have different extensions. That depends on the type of animation they are intended to be. See the [animation data](~animation-data) page for information about the various extensions and the different types of animation.
+
+Add [rename.txt](~rename-txt) to reuse animations as other animations, without copying and renaming files.
 
 # String compilation
 UTF-8 text files containing strings can be compiled into a [string_list](~) using the `strings` verb:

--- a/src/content/h2/source-data/readme.md
+++ b/src/content/h2/source-data/readme.md
@@ -1,0 +1,7 @@
+---
+title: Source data files
+stub: true
+noSearch: true
+about: 'resource:Source data files'
+---
+...

--- a/src/content/h2/source-data/rename-txt/readme.md
+++ b/src/content/h2/source-data/rename-txt/readme.md
@@ -1,21 +1,27 @@
 ---
-title: rename.txt
+title: Text file for reusing animations
 about: 'resource:Animation data'
+keywords: 
+  - animation
+  - copy
+  - duplicate
+  - rename
+  - reuse
 thanks:
-  Abstract Ingenuity: Research and documentation
+  "Abstract Ingenuity": Research and documentation
 ---
 
 The file `rename.txt` is for reusing animations under different names.
 
 # Usage
 
-Source data files for animations go in a subfolder named `animations` as described [here](~h2/tools/h2-ek/h2-tool#model-animations). Create a text file named `rename` in that folder. Open the file in a text editor, make any necessary changes, then save.
+Source data files for animations go in a subfolder named `animations` as described [here](~h2-tool#model-animations). Create a text file named `rename` in that folder. Open the file in a text editor, make any necessary changes, then save.
 
 After importing all the animations, Tool will try to parse `rename.txt` and modify the `MODE-n-STATE GRAPH` inside the [model_animation_graph](~) tag according to the contents of that file.
 
 # Format
 
-Each line in `readme.txt` is written like this:  
+To reuse an animation as another animation, write a line in this format:
 ```
 name-of-animation = name-of-animation
 ```
@@ -53,7 +59,7 @@ first_person exit_full = first_person reload_exit
 first_person exit_empty = first_person reload_exit
 ```
 
-Output from [Tool](~h2/tools/h2-ek/h2-tool#fp-model-animations)
+Output from [Tool](~h2-tool#fp-model-animations)
 ```
 ### fp_shotgun.JMS
 ### fp_arms.JMS

--- a/src/content/h2/source-data/rename-txt/readme.md
+++ b/src/content/h2/source-data/rename-txt/readme.md
@@ -1,0 +1,85 @@
+---
+title: rename.txt
+about: 'resource:Animation data'
+thanks:
+  Abstract Ingenuity: Research and documentation
+---
+
+The file `rename.txt` is for reusing animations under different names.
+
+# Usage
+
+Source data files for animations go in a subfolder named `animations` as described [here](~h2/tools/h2-ek/h2-tool#model-animations). Create a text file named `rename` in that folder. Open the file in a text editor, make any necessary changes, then save.
+
+After importing all the animations, Tool will try to parse `rename.txt` and modify the `MODE-n-STATE GRAPH` inside the [model_animation_graph](~) tag according to the contents of that file.
+
+# Format
+
+Each line in `readme.txt` is written like this:  
+```
+name-of-animation = name-of-animation
+```
+
+There are three parts: the name of an animation that does not already exist, the equal sign, and the name of an animation that does exist.
+
+# Example
+
+Source data files
+```
+first_person fire_1.JMM
+first_person idle.JMM
+first_person melee_strike_1.JMM
+first_person melee_strike_2.JMM
+first_person moving.JMO
+first_person overlays.JMO
+first_person pitch_and_turn.JMO
+first_person posing var0.JMM
+first_person posing var1.JMM
+first_person ready.JMM
+first_person reload_continue_empty.JMM
+first_person reload_enter.JMM
+first_person reload_exit.JMM
+first_person sprint.JMR
+first_person throw_grenade.JMM
+rename.txt
+```
+
+Contents of `rename.txt`
+```
+first_person reload_continue_full = first_person reload_continue_empty
+first_person reload_empty = first_person reload_continue_empty
+first_person reload_full = first_person reload_continue_empty
+first_person exit_full = first_person reload_exit
+first_person exit_empty = first_person reload_exit
+```
+
+Output from [Tool](~h2/tools/h2-ek/h2-tool#fp-model-animations)
+```
+### fp_shotgun.JMS
+### fp_arms.JMS
+### first_person fire_1.JMM
+### first_person idle.JMM
+### first_person melee_strike_1.JMM
+### first_person melee_strike_2.JMM
+### first_person posing var0.JMM
+### first_person posing var1.JMM
+### first_person ready.JMM
+### first_person reload_continue_empty.JMM
+### first_person reload_enter.JMM
+### first_person reload_exit.JMM
+### first_person throw_grenade.JMM
+### first_person moving.JMO
+### first_person overlays.JMO
+### first_person pitch_and_turn.JMO
+### first_person sprint.JMR
+populating animation graph...
+processing rename.txt...
+### renamed "first_person:reload_continue_empty" ==> "first_person:reload_continue_full"
+### renamed "first_person:reload_continue_empty" ==> "first_person:reload_empty"
+### renamed "first_person:reload_continue_empty" ==> "first_person:reload_full"
+### renamed "first_person:reload_exit" ==> "first_person:exit_full"
+### renamed "first_person:reload_exit" ==> "first_person:exit_empty"
+restoring old animation graph data...
+sorting graph entries...
+RESULTS 0 errors, 0 warnings
+```

--- a/src/content/h2/tools/h2-ek/h2-tool/readme.md
+++ b/src/content/h2/tools/h2-ek/h2-tool/readme.md
@@ -482,6 +482,8 @@ tool fp-model-animations "objects\characters\masterchief\fp\weapons\rifle\fp_smg
 * weapon-directory - A local data path to the root of the first person weapon model source directory the character is using.
 * flags - ??? This is an optional arg.
 
+Add [rename.txt](~rename-txt) to reuse animations as other animations, without copying and renaming files.
+
 # Import damage table
 Imports `data\globals\armor_vs_damage.csv` to update the damage table block in [globals](~). The CSV (which can be exported from any spreadsheet software like Excel) uses Damage Groups as the columns, and Armor Modifiers as the rows, with each cell being the applicable Damage Multiplier.
 
@@ -676,6 +678,8 @@ tool model-animations "objects\characters\masterchief"
 * flags - ???
 
 For the example above, Tool would expect to find a set of corresponding animation source files at `data\objects\characters\masterchief\animations`. Assuming no errors, it would be compiled into `tags\objects\characters\masterchief\masterchief.model_animation_graph`.
+
+Add [rename.txt](~rename-txt) to reuse animations as other animations, without copying and renaming files.
 
 # Monitor changes
 These command monitor the data folder for changes and automatically reimport any data changed.

--- a/src/content/h3/h3-ek/h3-tool/readme.md
+++ b/src/content/h3/h3-ek/h3-tool/readme.md
@@ -8,8 +8,12 @@ keywords:
   - tool
   - lightmap
   - cli
+  - h3tool
 related:
   - /h1/tools/h1a-ek/h1a-tool
+  - /h2/tools/h2-ek/h2-tool
+thanks:
+  "Abstract Ingenuity": Documentation about commands for importing animations
 ---
 **H3-Tool** (**tool.exe**), is a [command-line](~) utility used to compile data into [tags](~), and tags into [maps](~map). It was released as a part of the [Halo 3 Editing Kit](~h3-ek) by 343 Industries in 2021.
 
@@ -712,6 +716,33 @@ tool fbx-to-jms render "F:\dreamer.fbx" "F:\dreamer.JMS"
 
 For some details on how to setup the FBX file see [FBX for H3](~fbx).
 
+# FP model animations
+
+```sh
+# fp-model-animations <source-directory> <character-directory> <weapon-directory>
+tool fp-model-animations "objects\characters\masterchief\fp\weapons\rifle\fp_assault_rifle" "objects\characters\masterchief\fp" "objects\weapons\rifle\assault_rifle\fp_assault_rifle"
+```
+
+- source-directory - A local data path to a folder that has a subfolder named `animations`
+- character-directory - A local data path to a folder that has a subfolder named `render` 
+- weapon-directory - A local data path to a folder that has a subfolder named `render`
+
+Tool expects the subfolder `animations` to have source data files for the first-person animations. Tool also expects each subfolder named `render` to have a [JMS](~) file. The first one is for the first-person arms, and the other is for the weapon. Those models should be the same models used to create the animations.
+
+Add [rename.txt](~rename-txt) to reuse animations as other animations, without copying and renaming files.
+
+For the given example, the animations will be compiled as a [model_animation_graph](~) tag in the folder `tags\objects\characters\masterchief\fp\weapons\rifle\fp_assault_rifle` if there are no serious errors.
+
+## Uncompressed
+
+By default, imported animations are compressed. Compression can be highly destructive for first-person animations. The arms and the weapon can be posed incorrectly. They can move in unexpected ways.
+
+Use this verb to import first-person animations without compression.
+```sh
+# fp-model-animations-uncompressed <source-directory> <character-directory> <weapon-directory>
+tool fp-model-animations-uncompressed "objects\characters\masterchief\fp\weapons\rifle\fp_assault_rifle" "objects\characters\masterchief\fp" "objects\weapons\rifle\assault_rifle\fp_assault_rifle"
+```
+
 # Import Bitmap Folder as Single Tag
 This command compiles multiple .tif files from a folder into a single .bitmap tag.
 
@@ -730,6 +761,30 @@ The individual images will be imported as separate "sequences", or layers, insid
 
 For images to be combined this way, Bungie naming convention is to name all of the images the same as the containing folder, with a numbered extension in square brackets for each. For example:
 `flares_generic[0], flares_generic[1], flares_generic[2]....`. However, this is optional, and in some cases it may be better to give the images distinct names so that they can be more easily recognized within the bitmap.
+
+# Model animations
+
+```sh
+# model-animations <source-directory>
+tool model-animations "objects\characters\masterchief"
+```
+
+- source-directory - A local data path to the root of a model source directory
+
+Tool expects a subfolder named `animations` that has animation data files. Tool also expects a subfolder named `render` that has a [JMS](~) file for the object. That model should be the same model used to create the animations.
+
+Add [rename.txt](~rename-txt) to reuse animations as other animations, without copying and renaming files.
+
+For the given example, the animations will be compiled as a [model_animation_graph](~) tag in the folder `tags\objects\characters\masterchief` if there are no serious errors.
+
+
+## Uncompressed
+
+Use this verb to import animations without compression.
+```sh
+# model-animations-uncompressed <source-directory>
+tool model-animations-uncompressed "objects\characters\masterchief"
+```
 
 # Sounds
 ## Reimport sounds

--- a/src/content/h3/source-data/readme.md
+++ b/src/content/h3/source-data/readme.md
@@ -1,0 +1,7 @@
+---
+title: Source data files
+stub: true
+noSearch: true
+about: 'resource:Source data files'
+---
+...

--- a/src/content/h3/source-data/rename-txt/readme.md
+++ b/src/content/h3/source-data/rename-txt/readme.md
@@ -1,15 +1,21 @@
 ---
-title: rename.txt
+title: Text file for reusing animations
 about: 'resource:Animation data'
+keywords: 
+  - animation
+  - copy
+  - duplicate
+  - rename
+  - reuse
 thanks:
-  Abstract Ingenuity: Research and documentation
+  "Abstract Ingenuity": Research and documentation
 ---
 
 The file `rename.txt` is for reusing animations under different names.
 
 # Usage
 
-Source data files for animations go in a subfolder named `animations` as described [here](~h2/tools/h2-ek/h2-tool#model-animations). Create a text file named `rename` in that folder. Open the file in a text editor, make any necessary changes, then save.
+Source data files for animations go in a subfolder named `animations` as described [here](~h3-tool#model-animations). Create a text file named `rename` in that folder. Open the file in a text editor, make any necessary changes, then save.
 
 After importing all the animations, Tool will try to parse `rename.txt` and modify the `MODE-n-STATE GRAPH` inside the [model_animation_graph](~) tag according to the contents of that file.
 
@@ -22,7 +28,7 @@ name-of-animation = name-of-animation
 
 There are three parts: the name of an animation that does not already exist, the equal sign, and the name of an animation that does exist.
 
-[Tool](~h3/h3-ek/h3-tool) can do that for multiple animations that belong to a specific mode, weapon class, and weapon type. It can reuse them as animations for another specific mode, weapon class and weapon type.
+[Tool](~h3-tool) can do that for multiple animations that belong to a specific mode, weapon class, and weapon type. It can reuse them as animations for another specific mode, weapon class and weapon type.
 
 To do that, write a line in this format:
 ```
@@ -40,15 +46,20 @@ mode-label weapon-class-label weapon-type-label
 
 Source data files
 ```
-any look.JMO
-combat idle.JMM
+combat pistol hp fire_1.JMO
+combat pistol hp melee_strike_1.JMR
+combat pistol hp melee_strike_2.JMR
 combat pistol hp reload_1.JMR
-combat rifle aim_move_up.JMO
-combat rifle aim_still_up.JMO
+combat pistol ne fire_1.JMO
+combat pistol ne melee_strike_1.JMR
+combat pistol ne reload_1.JMR
+combat pistol pp melee_strike_1.JMR
+combat pistol pp melee_strike_2.JMR
 combat rifle ar fire_1.JMO
-combat rifle ar melee.JMA
+combat rifle ar melee_strike_1.JMR
+combat rifle ar melee_strike_2.JMR
 combat rifle ar reload_1.JMR
-crouch idle.JMM
+combat rifle br fire_1.JMO
 pelican_p_l01 enter.JMM
 pelican_p_l01 exit.JMM
 pelican_p_l01 idle.JMM
@@ -60,12 +71,9 @@ rename.txt
 
 Contents of `rename.txt`
 ```
-combat melee = combat rifle ar melee
-combat rifle br fire_1 = combat rifle ar fire_1
-combat rifle br reload_1 = combat rifle ar reload_1
-crouch pistol hp reload_1 = combat pistol hp reload_1
-crouch rifle ar reload_1 = combat rifle ar reload_1
-copy_weapon_type combat pistol any = combat rifle any
+combat pistol ne melee_strike_2 = combat pistol hp melee_strike_1
+combat pistol pp fire_1 = combat pistol ne fire_1
+copy_weapon_type combat rifle br = combat rifle ar
 copy_weapon_type pelican_p_l02 any any = pelican_p_l01 any any
 copy_weapon_type pelican_p_l03 any any = pelican_p_l01 any any
 copy_weapon_type pelican_p_l04 any any = pelican_p_l01 any any
@@ -76,39 +84,38 @@ copy_weapon_type pelican_p_r04 any any = pelican_p_r01 any any
 copy_weapon_type pelican_p_r05 any any = pelican_p_r01 any any
 ```
 
-Output from [Tool](~h2/tools/h2-ek/h2-tool#model-animations)
+Output from [Tool](~h3-tool#model-animations)
 ```
 ### example.JMS
-### combat rifle ar melee.JMA
-### combat idle.JMM
-### crouch idle.JMM
 ### pelican_p_l01 enter.JMM
 ### pelican_p_l01 exit.JMM
 ### pelican_p_l01 idle.JMM
 ### pelican_p_r01 enter.JMM
 ### pelican_p_r01 exit.JMM
 ### pelican_p_r01 idle.JMM
-### any look.JMO
-### combat rifle aim_move_up.JMO
-### combat rifle aim_still_up.JMO
+### combat pistol hp fire_1.JMO
+### combat pistol ne fire_1.JMO
 ### combat rifle ar fire_1.JMO
+### combat rifle br fire_1.JMO
+### combat pistol hp melee_strike_1.JMR
+### combat pistol hp melee_strike_2.JMR
 ### combat pistol hp reload_1.JMR
+### combat pistol ne melee_strike_1.JMR
+### combat pistol ne reload_1.JMR
+### combat pistol pp melee_strike_1.JMR
+### combat pistol pp melee_strike_2.JMR
+### combat rifle ar melee_strike_1.JMR
+### combat rifle ar melee_strike_2.JMR
 ### combat rifle ar reload_1.JMR
 > populating animation graph...
 
 > processing rename.txt...
 
-> ### renamed "combat:rifle:ar:melee" ==> "combat:melee"
+> ### renamed "combat:pistol:hp:melee_strike_1" ==> "combat:pistol:ne:melee_strike_2"
 
-> ### renamed "combat:rifle:ar:fire_1" ==> "combat:rifle:br:fire_1"
+> ### renamed "combat:pistol:ne:fire_1" ==> "combat:pistol:pp:fire_1"
 
-> ### renamed "combat:rifle:ar:reload_1" ==> "combat:rifle:br:reload_1"
-
-> ### renamed "combat:pistol:hp:reload_1" ==> "crouch:pistol:hp:reload_1"
-
-> ### renamed "combat:rifle:ar:reload_1" ==> "crouch:rifle:ar:reload_1"
-
-> ### copied all 'combat:rifle:any' to 'combat:pistol:any'.
+> ### copied all 'combat:rifle:ar' to 'combat:rifle:br'.
 
 > ### copied all 'pelican_p_l01:any:any' to 'pelican_p_l02:any:any'.
 

--- a/src/content/h3/source-data/rename-txt/readme.md
+++ b/src/content/h3/source-data/rename-txt/readme.md
@@ -1,0 +1,134 @@
+---
+title: rename.txt
+about: 'resource:Animation data'
+thanks:
+  Abstract Ingenuity: Research and documentation
+---
+
+The file `rename.txt` is for reusing animations under different names.
+
+# Usage
+
+Source data files for animations go in a subfolder named `animations` as described [here](~h2/tools/h2-ek/h2-tool#model-animations). Create a text file named `rename` in that folder. Open the file in a text editor, make any necessary changes, then save.
+
+After importing all the animations, Tool will try to parse `rename.txt` and modify the `MODE-n-STATE GRAPH` inside the [model_animation_graph](~) tag according to the contents of that file.
+
+# Format
+
+To reuse an animation as another animation, write a line in this format:
+```
+name-of-animation = name-of-animation
+```
+
+There are three parts: the name of an animation that does not already exist, the equal sign, and the name of an animation that does exist.
+
+[Tool](~h3/h3-ek/h3-tool) can do that for multiple animations that belong to a specific mode, weapon class, and weapon type. It can reuse them as animations for another specific mode, weapon class and weapon type.
+
+To do that, write a line in this format:
+```
+copy_weapon_type name-of-block = name-of-block
+```
+
+There are four parts: the prefix that tells Tool to reuse animations in one block for another, the block that we want to reuse animations for, the equal sign, and a block that exists.
+
+The "name" of a block is written in this format:
+```
+mode-label weapon-class-label weapon-type-label
+```
+
+# Example
+
+Source data files
+```
+any look.JMO
+combat idle.JMM
+combat pistol hp reload_1.JMR
+combat rifle aim_move_up.JMO
+combat rifle aim_still_up.JMO
+combat rifle ar fire_1.JMO
+combat rifle ar melee.JMA
+combat rifle ar reload_1.JMR
+crouch idle.JMM
+pelican_p_l01 enter.JMM
+pelican_p_l01 exit.JMM
+pelican_p_l01 idle.JMM
+pelican_p_r01 enter.JMM
+pelican_p_r01 exit.JMM
+pelican_p_r01 idle.JMM
+rename.txt
+```
+
+Contents of `rename.txt`
+```
+combat melee = combat rifle ar melee
+combat rifle br fire_1 = combat rifle ar fire_1
+combat rifle br reload_1 = combat rifle ar reload_1
+crouch pistol hp reload_1 = combat pistol hp reload_1
+crouch rifle ar reload_1 = combat rifle ar reload_1
+copy_weapon_type combat pistol any = combat rifle any
+copy_weapon_type pelican_p_l02 any any = pelican_p_l01 any any
+copy_weapon_type pelican_p_l03 any any = pelican_p_l01 any any
+copy_weapon_type pelican_p_l04 any any = pelican_p_l01 any any
+copy_weapon_type pelican_p_l05 any any = pelican_p_l01 any any
+copy_weapon_type pelican_p_r02 any any = pelican_p_r01 any any
+copy_weapon_type pelican_p_r03 any any = pelican_p_r01 any any
+copy_weapon_type pelican_p_r04 any any = pelican_p_r01 any any
+copy_weapon_type pelican_p_r05 any any = pelican_p_r01 any any
+```
+
+Output from [Tool](~h2/tools/h2-ek/h2-tool#model-animations)
+```
+### example.JMS
+### combat rifle ar melee.JMA
+### combat idle.JMM
+### crouch idle.JMM
+### pelican_p_l01 enter.JMM
+### pelican_p_l01 exit.JMM
+### pelican_p_l01 idle.JMM
+### pelican_p_r01 enter.JMM
+### pelican_p_r01 exit.JMM
+### pelican_p_r01 idle.JMM
+### any look.JMO
+### combat rifle aim_move_up.JMO
+### combat rifle aim_still_up.JMO
+### combat rifle ar fire_1.JMO
+### combat pistol hp reload_1.JMR
+### combat rifle ar reload_1.JMR
+> populating animation graph...
+
+> processing rename.txt...
+
+> ### renamed "combat:rifle:ar:melee" ==> "combat:melee"
+
+> ### renamed "combat:rifle:ar:fire_1" ==> "combat:rifle:br:fire_1"
+
+> ### renamed "combat:rifle:ar:reload_1" ==> "combat:rifle:br:reload_1"
+
+> ### renamed "combat:pistol:hp:reload_1" ==> "crouch:pistol:hp:reload_1"
+
+> ### renamed "combat:rifle:ar:reload_1" ==> "crouch:rifle:ar:reload_1"
+
+> ### copied all 'combat:rifle:any' to 'combat:pistol:any'.
+
+> ### copied all 'pelican_p_l01:any:any' to 'pelican_p_l02:any:any'.
+
+> ### copied all 'pelican_p_l01:any:any' to 'pelican_p_l03:any:any'.
+
+> ### copied all 'pelican_p_l01:any:any' to 'pelican_p_l04:any:any'.
+
+> ### copied all 'pelican_p_l01:any:any' to 'pelican_p_l05:any:any'.
+
+> ### copied all 'pelican_p_r01:any:any' to 'pelican_p_r02:any:any'.
+
+> ### copied all 'pelican_p_r01:any:any' to 'pelican_p_r03:any:any'.
+
+> ### copied all 'pelican_p_r01:any:any' to 'pelican_p_r04:any:any'.
+
+> ### copied all 'pelican_p_r01:any:any' to 'pelican_p_r05:any:any'.
+
+> restoring old animation graph data...
+
+> sorting graph entries...
+
+> RESULTS 0 errors, 0 warnings
+```


### PR DESCRIPTION
Tool has a hidden (?) feature that allows us to reuse animations as other animations, without copying and renaming files. I have added information about the purpose of "rename.txt", details about the format of its contents, and examples.

In accordance with guidelines for contributing to c20, I have added links to the new pages on existing pages about H1CE Tool, H1A Tool, H2 Tool and H3 Tool. For H3 Tool, I also added documentation about commands for importing animations.
