### PR TITLE
h1 map.yml: swap order of checksum and scenario tag id

### DIFF
--- a/src/data/structs/h1/files/map.yml
+++ b/src/data/structs/h1/files/map.yml
@@ -285,14 +285,14 @@ type_defs:
         type: ptr32
         comments:
           en: A pointer to the tag array, which lists all tags in the map.
-      - name: checksum
-        type: uint32
-        comments:
-          en: A CRC32 checksum of the tag files used in the map.
       - name: scenario_tag_id
         type: uint32
         comments:
           en: Unique ID of the [scenario](~) tag in the tag array.
+      - name: checksum
+        type: uint32
+        comments:
+          en: A CRC32 checksum of the tag files used in the map.
       - name: tag_count
         type: uint32
         comments:


### PR DESCRIPTION
Current order seems to be incorrect, it states that the checksum and scenario tag id are at offset 0x4 and 0x8 respectively within the tag header.

However, looking at e.g. bloodgulch.map from custom edition, offset to tag header at 0x10:

```sh
$ hexdump -C bloodgulch.map | head
00000000  64 61 65 68 61 02 00 00  dc a5 d4 00 00 00 00 00  |daeha...........|
00000010  74 19 85 00 68 8c 4f 00  00 00 00 00 00 00 00 00  |t...h.O.........|
00000020  62 6c 6f 6f 64 67 75 6c  63 68 00 00 00 00 00 00  |bloodgulch......|
00000030  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000040  30 31 2e 30 30 2e 30 30  2e 30 36 30 39 00 00 00  |01.00.00.0609...|
00000050  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000060  01 00 00 00 54 95 30 7b  00 00 00 00 00 00 00 00  |....T.0{........|
00000070  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
000007f0  00 00 00 00 00 00 00 00  00 00 00 00 74 6f 6f 66  |............toof|
```

is 0x851974. The tag header at that offset

```sh
% hexdump -C bloodgulch.map -s $((0x851974)) | head -n1
00851974  28 00 44 40 00 00 74 e1  af df 7a 91 97 09 00 00  |(.D@..t...z.....|
```

shows that the value at 0x4 is 0xe1740000 and 0x8 is 0x917adfaf. The 0x0000 in the first value is the index to the scenario root tag and second value looks more like a checksum.